### PR TITLE
Feat : 레시피 댓글 API

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/recipecomment/RecipeComment.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/RecipeComment.java
@@ -41,4 +41,10 @@ public class RecipeComment extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "parentComment")
     private List<RecipeComment> childCommentList = new ArrayList<>();
+
+    public RecipeComment update(String content) {
+        this.content = content;
+        return this;
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/RecipeComment.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/RecipeComment.java
@@ -11,16 +11,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Builder
 public class RecipeComment extends BaseTimeEntity {
 
     @Id
@@ -33,6 +31,7 @@ public class RecipeComment extends BaseTimeEntity {
     @ColumnDefault("0")
     private Long parentId; //댓글 : 0, 대 댓글 : 자신의 부모 댓글 id
 
+    @Builder.Default
     private boolean state = true; //true : 존재, false : 삭제
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/RecipeComment.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/RecipeComment.java
@@ -47,4 +47,9 @@ public class RecipeComment extends BaseTimeEntity {
         return this;
     }
 
+    public RecipeComment delete() {
+        this.state = false;
+        return this;
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/RecipeComment.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/RecipeComment.java
@@ -1,18 +1,14 @@
 package com.example.dgbackend.domain.recipecomment;
 
-import com.example.dgbackend.domain.recipe.Recipe;
 import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.recipe.Recipe;
 import com.example.dgbackend.global.common.BaseTimeEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -28,8 +24,9 @@ public class RecipeComment extends BaseTimeEntity {
     @NotNull
     private String content;
 
-    @ColumnDefault("0")
-    private Long parentId; //댓글 : 0, 대 댓글 : 자신의 부모 댓글 id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private RecipeComment parentComment; //댓글 : 0, 대 댓글 : 자신의 부모 댓글 id
 
     @Builder.Default
     private boolean state = true; //true : 존재, false : 삭제
@@ -42,4 +39,6 @@ public class RecipeComment extends BaseTimeEntity {
     @JoinColumn(name = "recipe_id")
     private Recipe recipe;
 
+    @OneToMany(mappedBy = "parentComment")
+    private List<RecipeComment> childCommentList = new ArrayList<>();
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/controller/RecipeCommentController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/controller/RecipeCommentController.java
@@ -45,4 +45,9 @@ public class RecipeCommentController {
         return ApiResponse.onSuccess(recipeCommentService.updateRecipeComment(recipeCommentRequest));
     }
 
+    @DeleteMapping("/{recipeId}")
+    public ApiResponse<RecipeCommentResponse> deleteRecipeComment(@PathVariable Long recipeId) {
+        return ApiResponse.onSuccess(recipeCommentService.deleteRecipeComment(recipeId));
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/controller/RecipeCommentController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/controller/RecipeCommentController.java
@@ -40,14 +40,14 @@ public class RecipeCommentController {
         return ApiResponse.onSuccess(recipeCommentService.saveRecipeComment(paramVO));
     }
 
-    @PatchMapping("/{recipeId}")
-    public ApiResponse<RecipeCommentResponse> updateRecipeComment(@PathVariable Long recipeId, @RequestBody RecipeCommentRequest.Patch recipeCommentRequest) {
+    @PatchMapping
+    public ApiResponse<RecipeCommentResponse> updateRecipeComment(@RequestBody RecipeCommentRequest.Patch recipeCommentRequest) {
         return ApiResponse.onSuccess(recipeCommentService.updateRecipeComment(recipeCommentRequest));
     }
 
-    @DeleteMapping("/{recipeId}")
-    public ApiResponse<RecipeCommentResponse> deleteRecipeComment(@PathVariable Long recipeId) {
-        return ApiResponse.onSuccess(recipeCommentService.deleteRecipeComment(recipeId));
+    @DeleteMapping
+    public ApiResponse<RecipeCommentResponse> deleteRecipeComment(@RequestParam Long recipeCommentId) {
+        return ApiResponse.onSuccess(recipeCommentService.deleteRecipeComment(recipeCommentId));
     }
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/controller/RecipeCommentController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/controller/RecipeCommentController.java
@@ -1,0 +1,36 @@
+package com.example.dgbackend.domain.recipecomment.controller;
+
+import com.example.dgbackend.domain.enums.Gender;
+import com.example.dgbackend.domain.enums.SocialType;
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.member.repository.MemberRepository;
+import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentRequest;
+import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentResponse;
+import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentVO;
+import com.example.dgbackend.domain.recipecomment.service.RecipeCommentServiceImpl;
+import com.example.dgbackend.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/recipe-comments")
+public class RecipeCommentController {
+
+    private final RecipeCommentServiceImpl recipeCommentService;
+
+    //Default Member 생성
+    //TODO: @AutenticationPrincipal로 변경
+    private final MemberRepository memberRepository;
+    private Member defaultmember = Member.builder()
+            .name("김동규").email("email@email.com").birthDate("birthDate")
+            .phoneNumber("phoneNumber").nickName("nickName").gender(Gender.MALE).socialType(SocialType.APPLE)
+            .build();
+
+    @PostMapping("/{recipeId}")
+    public ApiResponse<RecipeCommentResponse> saveRecipeComment(@PathVariable Long recipeId, @RequestBody RecipeCommentRequest.Post recipeCommentRequest) {
+        RecipeCommentVO paramVO = RecipeCommentVO.of(recipeCommentRequest, recipeId, defaultmember.getName());
+        return ApiResponse.onSuccess(recipeCommentService.saveRecipeComment(paramVO));
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/controller/RecipeCommentController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/controller/RecipeCommentController.java
@@ -40,4 +40,9 @@ public class RecipeCommentController {
         return ApiResponse.onSuccess(recipeCommentService.saveRecipeComment(paramVO));
     }
 
+    @PatchMapping("/{recipeId}")
+    public ApiResponse<RecipeCommentResponse> updateRecipeComment(@PathVariable Long recipeId, @RequestBody RecipeCommentRequest.Patch recipeCommentRequest) {
+        return ApiResponse.onSuccess(recipeCommentService.updateRecipeComment(recipeCommentRequest));
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/controller/RecipeCommentController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/controller/RecipeCommentController.java
@@ -12,6 +12,8 @@ import com.example.dgbackend.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/recipe-comments")
@@ -26,6 +28,11 @@ public class RecipeCommentController {
             .name("김동규").email("email@email.com").birthDate("birthDate")
             .phoneNumber("phoneNumber").nickName("nickName").gender(Gender.MALE).socialType(SocialType.APPLE)
             .build();
+
+    @GetMapping("/{recipeId}")
+    public ApiResponse<List<RecipeCommentResponse>> getRecipeComments(@PathVariable Long recipeId) {
+        return ApiResponse.onSuccess(recipeCommentService.getRecipeComment(recipeId));
+    }
 
     @PostMapping("/{recipeId}")
     public ApiResponse<RecipeCommentResponse> saveRecipeComment(@PathVariable Long recipeId, @RequestBody RecipeCommentRequest.Post recipeCommentRequest) {

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/dto/RecipeCommentRequest.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/dto/RecipeCommentRequest.java
@@ -1,0 +1,29 @@
+package com.example.dgbackend.domain.recipecomment.dto;
+
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.recipe.Recipe;
+import com.example.dgbackend.domain.recipecomment.RecipeComment;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+public class RecipeCommentRequest {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @RequiredArgsConstructor
+    public static class Post {
+
+        @NotNull
+        private String content;
+
+        @NotNull
+        private Long parentId;
+
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/dto/RecipeCommentRequest.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/dto/RecipeCommentRequest.java
@@ -36,4 +36,18 @@ public class RecipeCommentRequest {
 
     }
 
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @RequiredArgsConstructor
+    public static class Patch {
+
+        @NotNull
+        private String content;
+
+        @NotNull
+        private Long recipeCommentId;
+
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/dto/RecipeCommentRequest.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/dto/RecipeCommentRequest.java
@@ -12,6 +12,16 @@ import lombok.RequiredArgsConstructor;
 
 public class RecipeCommentRequest {
 
+    public static RecipeComment toEntity(Member member, Recipe recipe, String comment, RecipeComment parentComment) {
+        return RecipeComment.builder()
+                .content(comment)
+                .state(true)
+                .member(member)
+                .parentComment(parentComment)
+                .recipe(recipe)
+                .build();
+    }
+
     @Getter
     @Builder
     @AllArgsConstructor

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/dto/RecipeCommentResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/dto/RecipeCommentResponse.java
@@ -25,22 +25,19 @@ public class RecipeCommentResponse {
 
     private String MemberName;
 
-    private boolean state;
-
     @Builder.Default
     private List<RecipeCommentResponse> childCommentList = new ArrayList<>();
 
     public static RecipeCommentResponse toResponse(RecipeComment recipeComment) {
 
         //부모 Comment가 null이면 0으로 설정, null이 아니면 부모 Comment의 id값으로 설정
-        Long parentId = Optional.of(recipeComment.getParentComment())
+        Long parentId = Optional.ofNullable(recipeComment.getParentComment())
                 .map(RecipeComment::getId)
                 .orElse(0L);
 
         return RecipeCommentResponse.builder()
                 .id(recipeComment.getId())
                 .content(recipeComment.getContent())
-                .state(recipeComment.isState())
                 .childCommentList(getList(recipeComment))
                 .MemberName(recipeComment.getMember().getName())
                 .build();
@@ -48,8 +45,14 @@ public class RecipeCommentResponse {
 
     private static List<RecipeCommentResponse> getList(RecipeComment recipeComment) {
         return Optional.ofNullable(recipeComment.getChildCommentList())
+
+                //자식없을 때
                 .orElse(new ArrayList<>())
-                .stream().map(RecipeCommentResponse::toResponse).toList();
+
+                //자식있을 때, 존재하는 것 만 반환
+                .stream()
+                .filter(RecipeComment::isState)
+                .map(RecipeCommentResponse::toResponse).toList();
     }
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/dto/RecipeCommentResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/dto/RecipeCommentResponse.java
@@ -1,0 +1,55 @@
+package com.example.dgbackend.domain.recipecomment.dto;
+
+import com.example.dgbackend.domain.recipecomment.RecipeComment;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RecipeCommentResponse {
+
+    @NotNull
+    private Long id;
+
+    @NotNull
+    private String content;
+
+    private String MemberName;
+
+    private boolean state;
+
+    @Builder.Default
+    private List<RecipeCommentResponse> childCommentList = new ArrayList<>();
+
+    public static RecipeCommentResponse toResponse(RecipeComment recipeComment) {
+
+        //부모 Comment가 null이면 0으로 설정, null이 아니면 부모 Comment의 id값으로 설정
+        Long parentId = Optional.of(recipeComment.getParentComment())
+                .map(RecipeComment::getId)
+                .orElse(0L);
+
+        return RecipeCommentResponse.builder()
+                .id(recipeComment.getId())
+                .content(recipeComment.getContent())
+                .state(recipeComment.isState())
+                .childCommentList(getList(recipeComment))
+                .MemberName(recipeComment.getMember().getName())
+                .build();
+    }
+
+    private static List<RecipeCommentResponse> getList(RecipeComment recipeComment) {
+        return Optional.ofNullable(recipeComment.getChildCommentList())
+                .orElse(new ArrayList<>())
+                .stream().map(RecipeCommentResponse::toResponse).toList();
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/dto/RecipeCommentVO.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/dto/RecipeCommentVO.java
@@ -1,0 +1,30 @@
+package com.example.dgbackend.domain.recipecomment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class RecipeCommentVO {
+
+    private String memberName;
+    private Long recipeId;
+    private String content;
+    private Long parentId;
+
+
+    public static RecipeCommentVO of(RecipeCommentRequest.Post recipeCommentRequest, Long recipeId, String memberName) {
+        return RecipeCommentVO.builder()
+                .memberName(memberName)
+                .recipeId(recipeId)
+                .content(recipeCommentRequest.getContent())
+                .parentId(recipeCommentRequest.getParentId())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/repository/RecipeCommentRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/repository/RecipeCommentRepository.java
@@ -1,0 +1,11 @@
+package com.example.dgbackend.domain.recipecomment.repository;
+
+import com.example.dgbackend.domain.recipecomment.RecipeComment;
+import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentResponse;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RecipeCommentRepository extends JpaRepository<RecipeComment, Long> {
+    List<RecipeComment> findAllByRecipeId(Long recipeId);
+}

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/repository/RecipeCommentRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/repository/RecipeCommentRepository.java
@@ -1,5 +1,6 @@
 package com.example.dgbackend.domain.recipecomment.repository;
 
+import com.example.dgbackend.domain.recipe.Recipe;
 import com.example.dgbackend.domain.recipecomment.RecipeComment;
 import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface RecipeCommentRepository extends JpaRepository<RecipeComment, Long> {
-    List<RecipeComment> findAllByRecipeId(Long recipeId);
+    List<RecipeComment> findAllByRecipe(Recipe recipe);
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
@@ -21,4 +21,5 @@ public interface RecipeCommentService {
 
     RecipeCommentResponse updateRecipeComment(RecipeCommentRequest.Patch requestDTO);
 
+    RecipeCommentResponse deleteRecipeComment(Long recipeCommentId);
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
@@ -1,8 +1,10 @@
 package com.example.dgbackend.domain.recipecomment.service;
 
 import com.example.dgbackend.domain.recipecomment.RecipeComment;
+import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentVO;
 
 public interface RecipeCommentService {
+    RecipeComment getEntity(RecipeCommentVO paramVO);
 
     RecipeComment getParentEntityById(Long id);
 

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
@@ -8,6 +8,9 @@ import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentVO;
 import java.util.List;
 
 public interface RecipeCommentService {
+
+    List<RecipeCommentResponse> getRecipeComment(Long recipeId);
+
     RecipeCommentResponse saveRecipeComment(RecipeCommentVO paramVO);
 
     RecipeComment getEntity(RecipeCommentVO paramVO);

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
@@ -3,6 +3,9 @@ package com.example.dgbackend.domain.recipecomment.service;
 import com.example.dgbackend.domain.recipecomment.RecipeComment;
 
 public interface RecipeCommentService {
+
+    RecipeComment getParentEntityById(Long id);
+
     RecipeComment getEntityById(Long id);
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
@@ -1,0 +1,8 @@
+package com.example.dgbackend.domain.recipecomment.service;
+
+import com.example.dgbackend.domain.recipecomment.RecipeComment;
+
+public interface RecipeCommentService {
+    RecipeComment getEntityById(Long id);
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
@@ -19,4 +19,6 @@ public interface RecipeCommentService {
 
     RecipeComment getEntityById(Long id);
 
+    RecipeCommentResponse updateRecipeComment(RecipeCommentRequest.Patch requestDTO);
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
@@ -1,9 +1,15 @@
 package com.example.dgbackend.domain.recipecomment.service;
 
 import com.example.dgbackend.domain.recipecomment.RecipeComment;
+import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentRequest;
+import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentResponse;
 import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentVO;
 
+import java.util.List;
+
 public interface RecipeCommentService {
+    RecipeCommentResponse saveRecipeComment(RecipeCommentVO paramVO);
+
     RecipeComment getEntity(RecipeCommentVO paramVO);
 
     RecipeComment getParentEntityById(Long id);

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
@@ -32,6 +32,7 @@ public class RecipeCommentServiceImpl implements RecipeCommentService{
         Recipe recipe = recipeService.getRecipe(recipeId);
 
         return recipeCommentRepository.findAllByRecipe(recipe).stream()
+                .filter(RecipeComment::isState)
                 .filter(recipeComment -> recipeComment.getParentComment() == null)
                 .map(RecipeCommentResponse::toResponse)
                 .toList();

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
@@ -74,4 +74,11 @@ public class RecipeCommentServiceImpl implements RecipeCommentService{
                 .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE_COMMENT));
     }
 
+    @Override
+    @Transactional
+    public RecipeCommentResponse updateRecipeComment(RecipeCommentRequest.Patch requestDTO) {
+        RecipeComment recipeComment = getEntityById(requestDTO.getRecipeCommentId()).update(requestDTO.getContent());
+        return RecipeCommentResponse.toResponse(recipeComment);
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
@@ -28,7 +28,10 @@ public class RecipeCommentServiceImpl implements RecipeCommentService{
 
     @Override
     public List<RecipeCommentResponse> getRecipeComment(Long recipeId) {
-        return recipeCommentRepository.findAllByRecipeId(recipeId).stream()
+
+        Recipe recipe = recipeService.getRecipe(recipeId);
+
+        return recipeCommentRepository.findAllByRecipe(recipe).stream()
                 .filter(recipeComment -> recipeComment.getParentComment() == null)
                 .map(RecipeCommentResponse::toResponse)
                 .toList();

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
@@ -1,17 +1,43 @@
 package com.example.dgbackend.domain.recipecomment.service;
 
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.member.service.MemberService;
+import com.example.dgbackend.domain.recipe.Recipe;
+import com.example.dgbackend.domain.recipe.service.RecipeService;
 import com.example.dgbackend.domain.recipecomment.RecipeComment;
+import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentRequest;
+import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentVO;
 import com.example.dgbackend.domain.recipecomment.repository.RecipeCommentRepository;
 import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
 import com.example.dgbackend.global.exception.ApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class RecipeCommentServiceImpl implements RecipeCommentService {
 
     private final RecipeCommentRepository recipeCommentRepository;
+    private final MemberService memberService;
+    private final RecipeService recipeService;
+
+    @Override
+    public RecipeComment getEntity(RecipeCommentVO paramVO) {
+        Member member = memberService.findMemberByName(paramVO.getMemberName());
+        Recipe recipe = recipeService.getRecipe(paramVO.getRecipeId());
+        String content = paramVO.getContent();
+
+        return Optional.ofNullable(paramVO.getParentId())
+
+                //대댓글 일 때
+                .filter(parentId -> parentId != 0)
+                .map(parentId -> RecipeCommentRequest.toEntity(member, recipe, content, getParentEntityById(parentId)))
+
+                //댓글 일 때
+                .orElse(RecipeCommentRequest.toEntity(member, recipe, content, null));
+    }
 
     @Override
     public RecipeComment getParentEntityById(Long parentId) {

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
@@ -6,10 +6,12 @@ import com.example.dgbackend.domain.recipe.Recipe;
 import com.example.dgbackend.domain.recipe.service.RecipeService;
 import com.example.dgbackend.domain.recipecomment.RecipeComment;
 import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentRequest;
+import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentResponse;
 import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentVO;
 import com.example.dgbackend.domain.recipecomment.repository.RecipeCommentRepository;
 import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
 import com.example.dgbackend.global.exception.ApiException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -22,6 +24,12 @@ public class RecipeCommentServiceImpl implements RecipeCommentService {
     private final RecipeCommentRepository recipeCommentRepository;
     private final MemberService memberService;
     private final RecipeService recipeService;
+
+    @Override
+    @Transactional
+    public RecipeCommentResponse saveRecipeComment(RecipeCommentVO paramVO) {
+        return RecipeCommentResponse.toResponse(recipeCommentRepository.save(getEntity(paramVO)));
+    }
 
     @Override
     public RecipeComment getEntity(RecipeCommentVO paramVO) {

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
@@ -1,0 +1,22 @@
+package com.example.dgbackend.domain.recipecomment.service;
+
+import com.example.dgbackend.domain.recipecomment.RecipeComment;
+import com.example.dgbackend.domain.recipecomment.repository.RecipeCommentRepository;
+import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
+import com.example.dgbackend.global.exception.ApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecipeCommentServiceImpl implements RecipeCommentService {
+
+    private final RecipeCommentRepository recipeCommentRepository;
+
+    @Override
+    public RecipeComment getEntityById(Long id) {
+        return recipeCommentRepository.findById(id)
+                .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE_COMMENT));
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
@@ -81,4 +81,14 @@ public class RecipeCommentServiceImpl implements RecipeCommentService{
         return RecipeCommentResponse.toResponse(recipeComment);
     }
 
+    @Override
+    @Transactional
+    public RecipeCommentResponse deleteRecipeComment(Long recipeCommentId) {
+        RecipeComment recipeComment = getEntityById(recipeCommentId).delete();
+
+        //대댓글도 삭제
+        recipeComment.getChildCommentList().forEach(RecipeComment::delete);
+        return RecipeCommentResponse.toResponse(recipeComment);
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
@@ -14,6 +14,18 @@ public class RecipeCommentServiceImpl implements RecipeCommentService {
     private final RecipeCommentRepository recipeCommentRepository;
 
     @Override
+    public RecipeComment getParentEntityById(Long parentId) {
+        RecipeComment ParentRecipeComment = getEntityById(parentId);
+
+        //부모의 부모 댓글이 존재할 경우
+        if (ParentRecipeComment.getParentComment() != null) {
+            throw new ApiException(ErrorStatus._OVER_DEPTH_RECIPE_COMMENT);
+        }
+
+        return ParentRecipeComment;
+    }
+
+    @Override
     public RecipeComment getEntityById(Long id) {
         return recipeCommentRepository.findById(id)
                 .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE_COMMENT));

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
@@ -15,15 +15,24 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-public class RecipeCommentServiceImpl implements RecipeCommentService {
+public class RecipeCommentServiceImpl implements RecipeCommentService{
 
     private final RecipeCommentRepository recipeCommentRepository;
     private final MemberService memberService;
     private final RecipeService recipeService;
+
+    @Override
+    public List<RecipeCommentResponse> getRecipeComment(Long recipeId) {
+        return recipeCommentRepository.findAllByRecipeId(recipeId).stream()
+                .filter(recipeComment -> recipeComment.getParentComment() == null)
+                .map(RecipeCommentResponse::toResponse)
+                .toList();
+    }
 
     @Override
     @Transactional
@@ -52,7 +61,7 @@ public class RecipeCommentServiceImpl implements RecipeCommentService {
         RecipeComment ParentRecipeComment = getEntityById(parentId);
 
         //부모의 부모 댓글이 존재할 경우
-        if (ParentRecipeComment.getParentComment() != null) {
+        if(ParentRecipeComment.getParentComment() != null) {
             throw new ApiException(ErrorStatus._OVER_DEPTH_RECIPE_COMMENT);
         }
 

--- a/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
@@ -22,6 +22,14 @@ public enum ErrorStatus implements BaseErrorCode {
     _EMPTY_JWT(HttpStatus.UNAUTHORIZED, "AUTH_001", "JWT가 존재하지 않습니다."),
     _INVALID_JWT(HttpStatus.UNAUTHORIZED, "AUTH_002", "유효하지 않은 JWT입니다.");
 
+    //레시피
+    _EMPTY_RECIPE(HttpStatus.CONFLICT, "RECIPE_001", "존재하지 않는 레시피입니다."),
+    _DELETE_RECIPE(HttpStatus.BAD_REQUEST, "RECIPE_002", "삭제된 레시피입니다."),
+    _ALREADY_CREATE_RECIPE(HttpStatus.BAD_REQUEST, "RECIPE_003", "이미 존재하는 레시피입니다."),
+
+    //레시피 댓글
+    _EMPTY_RECIPE_COMMENT(HttpStatus.CONFLICT, "RECIPE_COMMENT_001", "존재하지 않는 레시피 댓글입니다.");
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
@@ -28,7 +28,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _ALREADY_CREATE_RECIPE(HttpStatus.BAD_REQUEST, "RECIPE_003", "이미 존재하는 레시피입니다."),
 
     //레시피 댓글
-    _EMPTY_RECIPE_COMMENT(HttpStatus.CONFLICT, "RECIPE_COMMENT_001", "존재하지 않는 레시피 댓글입니다.");
+    _EMPTY_RECIPE_COMMENT(HttpStatus.CONFLICT, "RECIPE_COMMENT_001", "존재하지 않는 레시피 댓글입니다."),
+    _OVER_DEPTH_RECIPE_COMMENT(HttpStatus.BAD_REQUEST, "RECIPE_COMMENT_003", "대댓글까지만 가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 요약

- Recipe-Comments API 

## 상세 내용

- 기본적인 DTO 추가하였습니다
- json 반환 시 직관성 & 프론트에서의 편의성을 위해 수정하였습니다. 이하 변경 사항 입니다.
    - parent_id 속성을 Long 타입이 아닌 RecipeComment 형으로 참조하게 하였습니다.
    - childCommentList을 추가하여 반환 시 해당 Comment의 자식 Comment를 한번에 반환할 수 있도록 하였습니다.

- 댓글 조회는 삭제되지않은 댓글만 조회하도록 하였습니다. 

- API 목록
    - (GET) /recipe-comments/{recipeId} : 해당 레시피의 모든 댓글 조회
    - (POST) /recipe-comments/{recipeId} : 해당 레시피에 댓글 등록
    - (PATCH) /recipes-comment : 레시피 댓글 수정
    - (DELETE) /recipes-comments : 레시피 댓글 삭제 

### Postman 테스트

- 레시피 댓글 등록
<img width="954" alt="스크린샷 2024-01-20 001954" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/e8fbb924-32a5-4426-864a-eaf14b1f5700">

- 삭제되지 않은 댓글 & 대댓글 조회
<img width="958" alt="스크린샷 2024-01-20 002005" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/98e2efe6-e239-4dd9-b234-6f9c9145c9c5">
<img width="955" alt="스크린샷 2024-01-20 002102" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/efd0ad79-e923-4901-8d83-e9ba5b592ff2">

- 레시피 수정
<img width="953" alt="스크린샷 2024-01-20 002226" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/8e1c3567-2a8a-4651-93e2-fe880c8ea842">
<img width="956" alt="스크린샷 2024-01-20 002245" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/ce28a1e8-3fc7-491e-99bc-cb3f14af7996">

- 레시피 삭제 
<img width="960" alt="스크린샷 2024-01-20 002351" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/ba747c02-d6a1-4ce5-8ffd-d70a441cdeef">

---

#### 예외

-대댓글 이상 등록
<img width="957" alt="스크린샷 2024-01-20 002050" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/ce5c0fce-b18b-409a-8582-9ddc2573ee9e">


## 질문 및 이외 사항

- 이전 #35 의 merge가 선행되야하는 작업이지만 코드리뷰하시기 편하기 위해 develop브랜치에서 새롭게 분기하여 해당 작업 내용만 cherry-pick하였습니다. 참고부탁드려요! ☺️ 

## 이슈 번호

- Close  #33 