### PR TITLE
FIX: 오늘의 조합 상세 조회 API 수정

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationResponse.java
@@ -123,6 +123,7 @@ public class CombinationResponse {
         String title;
         String content;
         List<String> hashTagList;
+        List<String> combinationImageList;
     }
 
     public static CombinationResult toCombinationResult(Combination combination,
@@ -131,11 +132,16 @@ public class CombinationResponse {
                 .map(hto -> hto.getHashTag().getName())
                 .toList();
 
+        List<String> imageList = combination.getCombinationImages().stream()
+                .map(CombinationImage::getImageUrl)
+                .toList();
+
         return CombinationResult.builder()
                 .combinationId(combination.getId())
                 .title(combination.getTitle())
                 .content(combination.getContent())
                 .hashTagList(hashTagList)
+                .combinationImageList(imageList)
                 .build();
     }
 

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -60,6 +60,7 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
                 () -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND)
         );
 
+        // HashTagOption
         List<HashTagOption> hashTagOptions = hashTagOptionRepository.findAllByCombinationWithFetch(combination);
         CombinationResult combinationResult = toCombinationResult(combination, hashTagOptions);
 


### PR DESCRIPTION
Related: #47

## 요약

- 오늘의 조합 상세 조회에 CombinationImage 정보 함께 전달하기

## 상세 내용

- 오늘의 조합 상세 조회시 누락된 CombinationImage 정보를 전달합니다.

## 질문 및 이외 사항

1. CombinationImage에 더미 데이터 넣기
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/3ad25a2f-6d81-48d9-b91e-60e01c128916)

<br/>

2. "/combinations/{combinationId}" API 실행결과 ( combinationId = 1)
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/50c460b7-74da-410a-bec2-bae63e62b50c)


## 이슈 번호

- close #47 