### PR TITLE
Feat : 레시피 좋아요 API

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/recipelike/RecipeLike.java
+++ b/src/main/java/com/example/dgbackend/domain/recipelike/RecipeLike.java
@@ -10,15 +10,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Builder
 public class RecipeLike extends BaseTimeEntity {
 
     @Id
@@ -34,5 +32,10 @@ public class RecipeLike extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recipe_id")
     private Recipe recipe;
+
+    public RecipeLike changeState() {
+        this.state = !this.state;
+        return this;
+    }
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipelike/controller/RecipeLikeController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipelike/controller/RecipeLikeController.java
@@ -1,0 +1,36 @@
+package com.example.dgbackend.domain.recipelike.controller;
+
+import com.example.dgbackend.domain.enums.Gender;
+import com.example.dgbackend.domain.enums.SocialType;
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.member.repository.MemberRepository;
+import com.example.dgbackend.domain.recipelike.dto.RecipeLikeVO;
+import com.example.dgbackend.domain.recipelike.service.RecipeLikeServiceImpl;
+import com.example.dgbackend.domain.recipelike.dto.RecipeLikeResponse;
+import com.example.dgbackend.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/recipe-likes")
+@RequiredArgsConstructor
+@Slf4j
+public class RecipeLikeController {
+
+    private final RecipeLikeServiceImpl recipeLikeServiceImpl;
+
+    //Default Member 생성
+    //TODO: @AutenticationPrincipal로 변경
+    private final MemberRepository memberRepository;
+    private Member DefaultMember = Member.builder()
+            .name("김동규").email("email@email.com").birthDate("birthDate")
+            .phoneNumber("phoneNumber").nickName("nickName").gender(Gender.MALE).socialType(SocialType.APPLE)
+            .build();
+
+    @GetMapping("/{recipeId}")
+    public ApiResponse<RecipeLikeResponse> getRecipeLikes(@PathVariable Long recipeId) {
+        return ApiResponse.onSuccess(recipeLikeServiceImpl.getRecipeLike(RecipeLikeVO.of(recipeId, DefaultMember.getName())));
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipelike/controller/RecipeLikeController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipelike/controller/RecipeLikeController.java
@@ -33,4 +33,9 @@ public class RecipeLikeController {
         return ApiResponse.onSuccess(recipeLikeServiceImpl.getRecipeLike(RecipeLikeVO.of(recipeId, DefaultMember.getName())));
     }
 
+    @PostMapping("/{recipeId}")
+    public ApiResponse<RecipeLikeResponse> createRecipeLike(@PathVariable Long recipeId) {
+        return ApiResponse.onSuccess(recipeLikeServiceImpl.changeRecipeLike(RecipeLikeVO.of(recipeId, DefaultMember.getName())));
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipelike/dto/RecipeLikeRequest.java
+++ b/src/main/java/com/example/dgbackend/domain/recipelike/dto/RecipeLikeRequest.java
@@ -1,0 +1,17 @@
+package com.example.dgbackend.domain.recipelike.dto;
+
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.recipe.Recipe;
+import com.example.dgbackend.domain.recipelike.RecipeLike;
+
+public class RecipeLikeRequest {
+
+    public static RecipeLike toEntity(Recipe recipe, Member member) {
+        return RecipeLike.builder()
+                .recipe(recipe)
+                .member(member)
+                .state(true)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipelike/dto/RecipeLikeResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/recipelike/dto/RecipeLikeResponse.java
@@ -1,0 +1,29 @@
+package com.example.dgbackend.domain.recipelike.dto;
+
+import com.example.dgbackend.domain.recipelike.RecipeLike;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecipeLikeResponse {
+
+    private boolean state;
+
+    public static RecipeLikeResponse toResponseByState(boolean state) {
+        return RecipeLikeResponse.builder()
+                .state(state)
+                .build();
+    }
+
+    public static RecipeLikeResponse toResponseByEntity(RecipeLike recipeLike) {
+        return RecipeLikeResponse.builder()
+                .state(recipeLike.isState())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipelike/dto/RecipeLikeVO.java
+++ b/src/main/java/com/example/dgbackend/domain/recipelike/dto/RecipeLikeVO.java
@@ -1,0 +1,20 @@
+package com.example.dgbackend.domain.recipelike.dto;
+
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.recipe.Recipe;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecipeLikeVO {
+
+    private Long RecipeId;
+    private String memberName;
+
+    public static RecipeLikeVO of(Long id, String name) {
+        return new RecipeLikeVO(id, name);
+    }
+}

--- a/src/main/java/com/example/dgbackend/domain/recipelike/service/RecipeLikeService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipelike/service/RecipeLikeService.java
@@ -10,6 +10,10 @@ public interface RecipeLikeService {
 
     RecipeLikeResponse getRecipeLike(RecipeLikeVO recipeLikeVO);
 
+    RecipeLikeResponse changeRecipeLike(RecipeLikeVO recipeLikeVO);
+
+    RecipeLike createRecipe(RecipeLikeVO recipeLikeVO);
+
     Optional<RecipeLike> getRecipeLikeEntity(RecipeLikeVO recipeLikeVO);
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipelike/service/RecipeLikeService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipelike/service/RecipeLikeService.java
@@ -1,0 +1,15 @@
+package com.example.dgbackend.domain.recipelike.service;
+
+import com.example.dgbackend.domain.recipelike.RecipeLike;
+import com.example.dgbackend.domain.recipelike.dto.RecipeLikeResponse;
+import com.example.dgbackend.domain.recipelike.dto.RecipeLikeVO;
+
+import java.util.Optional;
+
+public interface RecipeLikeService {
+
+    RecipeLikeResponse getRecipeLike(RecipeLikeVO recipeLikeVO);
+
+    Optional<RecipeLike> getRecipeLikeEntity(RecipeLikeVO recipeLikeVO);
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipelike/service/RecipeLikeServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipelike/service/RecipeLikeServiceImpl.java
@@ -1,0 +1,43 @@
+package com.example.dgbackend.domain.recipelike.service;
+
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.member.service.MemberService;
+import com.example.dgbackend.domain.recipe.Recipe;
+import com.example.dgbackend.domain.recipe.service.RecipeServiceImpl;
+import com.example.dgbackend.domain.recipelike.RecipeLike;
+import com.example.dgbackend.domain.recipelike.dto.RecipeLikeResponse;
+import com.example.dgbackend.domain.recipelike.dto.RecipeLikeVO;
+import com.example.dgbackend.domain.recipelike.repository.RecipeLikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RecipeLikeServiceImpl implements RecipeLikeService {
+
+    private final RecipeLikeRepository recipeLikeRepository;
+    private final RecipeServiceImpl recipeServiceImpl;
+    private final MemberService memberService;
+
+    @Override
+    public RecipeLikeResponse getRecipeLike(RecipeLikeVO recipeLikeVO) {
+
+        Optional<RecipeLike> recipeLike = getRecipeLikeEntity(recipeLikeVO);
+
+        //레시피 좋아요 엔티티가 존재하면 해당 엔티티의 state를 반환
+        //존재하지 않으면 false를 반환
+        return recipeLike.map(RecipeLikeResponse::toResponseByEntity)
+                .orElseGet(() -> RecipeLikeResponse.toResponseByState(false));
+    }
+
+    //레시피 id와 멤버 이름으로 레시피 좋아요 엔티티를 조회
+    @Override
+    public Optional<RecipeLike> getRecipeLikeEntity(RecipeLikeVO recipeLikeVO) {
+        Recipe recipe = recipeServiceImpl.getRecipe(recipeLikeVO.getRecipeId());
+        Member memberByName = memberService.findMemberByName(recipeLikeVO.getMemberName());
+        return recipeLikeRepository.findByRecipeAndMember(recipe, memberByName);
+    }
+
+}


### PR DESCRIPTION
## 요약

- Recipe-Likes API 

## 상세 내용

- 유저의 좋아요 여부 & 클릭시 API 입니다.
- 기본 유저는 Default User를 생성해 사용하였고 추후 security 파트완료시 코드 수정하겠습니다.

- API 목록
    - (GET) /recipe-likes/{recipeId} : 해당 레시피에 좋아요 여부
    - (POST) /recipe-likes/{recipeId} : 해당 레시피에 좋아요 누를 때  수정

### Postman 테스트

- 레시피 좋아요 여부
<img width="958" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/ab5fea75-5db3-4af8-a3d9-a9f259e04e25">

- like 클릭 시 API
<img width="954" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/2fafd293-9082-4ef4-940c-46057a489f63">

## 질문 및 이외 사항

- 현재 /recipe-likes/{recipeId}로 구현했는데 PathVariable이 괜찮을지 param으로 좋을지 추후 프론트 담당자 분과 의견 나누려고 합니다! 의견있으시면 말씀해주세요!

## 이슈 번호

- Close  #34 