### PR TITLE
[FEAT] 오늘의 조합 댓글 조회 API 개발

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
@@ -5,17 +5,21 @@ import com.example.dgbackend.domain.combination.dto.CombinationResponse;
 import com.example.dgbackend.domain.combination.service.CombinationCommandService;
 import com.example.dgbackend.domain.combination.service.CombinationQueryService;
 import com.example.dgbackend.global.common.response.ApiResponse;
+import com.example.dgbackend.global.validation.annotation.CheckPage;
+import com.example.dgbackend.global.validation.annotation.ExistCombination;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 
 @Tag(name = "오늘의 조합 API")
 @RestController
+@Validated
 @RequestMapping("/combinations")
 @RequiredArgsConstructor
 public class CombinationController {
@@ -29,7 +33,7 @@ public class CombinationController {
     })
     @Parameter(name = "page", description = "오늘의 조합 목록 페이지 번호, query string 입니다.")
     @GetMapping("")
-    public ApiResponse<CombinationResponse.CombinationPreviewResultList> getCombinations(@RequestParam(name = "page") Integer page) {
+    public ApiResponse<CombinationResponse.CombinationPreviewResultList> getCombinations(@CheckPage @RequestParam(name = "page") Integer page) {
         return ApiResponse.onSuccess(combinationQueryService.getCombinationPreviewResultList(page));
     }
 
@@ -39,7 +43,7 @@ public class CombinationController {
     })
     @Parameter(name = "combinationId", description = "오늘의 조합 Id, Path Variable 입니다.")
     @GetMapping("/{combinationId}")
-    public ApiResponse<CombinationResponse.CombinationDetailResult> getDetailCombination(@PathVariable(name = "combinationId") Long combinationId) {
+    public ApiResponse<CombinationResponse.CombinationDetailResult> getDetailCombination(@ExistCombination @PathVariable(name = "combinationId") Long combinationId) {
         return ApiResponse.onSuccess(combinationQueryService.getCombinationDetailResult(combinationId));
     }
 
@@ -63,7 +67,7 @@ public class CombinationController {
     })
     @Parameter(name = "combinationId", description = "오늘의 조합 Id, Path Variable 입니다.")
     @GetMapping("/{combinationId}/edit")
-    public ApiResponse<CombinationResponse.CombinationEditResult> editCombination(@PathVariable(name = "combinationId") Long combinationId) {
+    public ApiResponse<CombinationResponse.CombinationEditResult> editCombination(@ExistCombination @PathVariable(name = "combinationId") Long combinationId) {
         return ApiResponse.onSuccess(combinationQueryService.getCombinationEditResult(combinationId));
     }
 
@@ -73,7 +77,7 @@ public class CombinationController {
     })
     @Parameter(name = "combinationId", description = "오늘의 조합 Id, Path Variable 입니다.")
     @PatchMapping("/{combinationId}")
-    public ApiResponse<CombinationResponse.CombinationProcResult> editProcCombination(@PathVariable(name = "combinationId") Long combinationId,
+    public ApiResponse<CombinationResponse.CombinationProcResult> editProcCombination(@ExistCombination @PathVariable(name = "combinationId") Long combinationId,
                                                                                       @RequestPart(name = "writeCombination") CombinationRequest.WriteCombination request) throws IOException {
         return ApiResponse.onSuccess(combinationCommandService.editCombination(combinationId, request));
     }
@@ -84,7 +88,7 @@ public class CombinationController {
     })
     @Parameter(name = "combinationId", description = "오늘의 조합 Id, Path Variable 입니다.")
     @DeleteMapping("/{combinationId}")
-    public ApiResponse<CombinationResponse.CombinationProcResult> deleteCombination(@PathVariable(name = "combinationId") Long combinationId) {
+    public ApiResponse<CombinationResponse.CombinationProcResult> deleteCombination(@ExistCombination @PathVariable(name = "combinationId") Long combinationId) {
 
         return ApiResponse.onSuccess(combinationCommandService.deleteCombination(combinationId));
     }

--- a/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationResponse.java
@@ -101,12 +101,12 @@ public class CombinationResponse {
     public static class CombinationDetailResult {
         CombinationResult combinationResult;
         MemberResponse.MemberResult memberResult;
-        CombinationCommentResponse.CombinationCommentResult combinationCommentResult;
+        CombinationCommentResponse.CommentPreViewResult combinationCommentResult;
     }
 
     public static CombinationDetailResult toCombinationDetailResult(CombinationResult combinationResult,
                                                                     MemberResponse.MemberResult memberResult,
-                                                                    CombinationCommentResponse.CombinationCommentResult combinationCommentResult) {
+                                                                    CombinationCommentResponse.CommentPreViewResult combinationCommentResult) {
         return CombinationDetailResult.builder()
                 .combinationResult(combinationResult)
                 .memberResult(memberResult)

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
@@ -9,4 +9,6 @@ public interface CombinationQueryService {
     CombinationDetailResult getCombinationDetailResult(Long combinationId);
 
     CombinationEditResult getCombinationEditResult(Long combinationId);
+
+    boolean existCombination(Long combinationId);
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -3,8 +3,6 @@ package com.example.dgbackend.domain.combination.service;
 import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.combination.dto.CombinationResponse;
 import com.example.dgbackend.domain.combination.repository.CombinationRepository;
-import com.example.dgbackend.domain.combinationcomment.CombinationComment;
-import com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse;
 import com.example.dgbackend.domain.combinationcomment.service.CombinationCommentQueryService;
 import com.example.dgbackend.domain.combinationimage.CombinationImage;
 import com.example.dgbackend.domain.hashtagoption.HashTagOption;
@@ -22,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static com.example.dgbackend.domain.combination.dto.CombinationResponse.*;
-import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.toCombinationCommentResult;
+import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentPreViewResult;
 import static com.example.dgbackend.domain.member.dto.MemberResponse.toMemberResult;
 
 @Service
@@ -68,10 +66,7 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
         MemberResponse.MemberResult memberResult = toMemberResult(member);
 
         // CombinationComment
-        Page<CombinationComment> combinationComments =
-                combinationCommentQueryService.getCombinationCommentFromCombination(combination, PageRequest.of(0, 10));
-
-        CombinationCommentResponse.CombinationCommentResult combinationCommentResult = toCombinationCommentResult(combinationComments);
+        CommentPreViewResult combinationCommentResult = combinationCommentQueryService.getCommentsFromCombination(combinationId, 0);
 
         return toCombinationDetailResult(combinationResult, memberResult, combinationCommentResult);
     }

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -87,4 +87,9 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
 
         return CombinationResponse.toCombinationEditResult(combination, hashTagOptions, combinationImages);
     }
+
+    @Override
+    public boolean existCombination(Long combinationId) {
+        return combinationRepository.existsById(combinationId);
+    }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/CombinationComment.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/CombinationComment.java
@@ -6,7 +6,8 @@ import com.example.dgbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
+import java.util.ArrayList;
+import java.util.List;
 
 @Builder
 @Getter
@@ -22,9 +23,11 @@ public class CombinationComment extends BaseTimeEntity {
     @NotNull
     private String content;
 
-    @ColumnDefault("0")
-    private Long parentId; //댓글 : 0, 대 댓글 : 자신의 부모 댓글 id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private CombinationComment parentComment; //댓글 : 0, 대 댓글 : 자신의 부모 댓글 id
 
+    @Builder.Default
     private boolean state = true; //true : 존재, false : 삭제
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -34,6 +37,9 @@ public class CombinationComment extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "combination_id")
     private Combination combination;
+
+    @OneToMany(mappedBy = "parentComment")
+    private List<CombinationComment> childComments = new ArrayList<>();
 
     //== 연관관계 관련 메서드 ==//
     public void setCombination(Combination combination) {

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/controller/CombinationCommentController.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/controller/CombinationCommentController.java
@@ -1,13 +1,37 @@
 package com.example.dgbackend.domain.combinationcomment.controller;
 
+import com.example.dgbackend.domain.combinationcomment.service.CombinationCommentQueryService;
+import com.example.dgbackend.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentPreViewResult;
 
 @Tag(name = "오늘의 조합 댓글 관련 API")
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/combination-comments")
 public class CombinationCommentController {
 
+    private final CombinationCommentQueryService combinationCommentQueryService;
 
+    @Operation(summary = "특정 오늘의 조합의 댓글 페이징 조회 ", description = "특정 오늘의 조합의 댓글을 조회합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 댓글 작성 성공")
+    })
+    @Parameters({
+            @Parameter(name = "combinationId", description = "댓글을 작성하는 오늘의 조합 Id, Path Variable 입니다."),
+            @Parameter(name = "page", description = "특정 오늘의 조합의  댓글 목록 페이지 번호, query string 입니다.")
+    })
+    @GetMapping("/{combinationId}")
+    public ApiResponse<CommentPreViewResult> getCombinationComments(@PathVariable(name = "combinationId") Long combinationId,
+                                                                    @RequestParam(name = "page") Integer page) {
+
+        return ApiResponse.onSuccess(combinationCommentQueryService.getCommentsFromCombination(combinationId, page));
+    }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/controller/CombinationCommentController.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/controller/CombinationCommentController.java
@@ -3,6 +3,7 @@ package com.example.dgbackend.domain.combinationcomment.controller;
 import com.example.dgbackend.domain.combinationcomment.service.CombinationCommentQueryService;
 import com.example.dgbackend.global.common.response.ApiResponse;
 import com.example.dgbackend.global.validation.annotation.CheckPage;
+import com.example.dgbackend.global.validation.annotation.ExistCombination;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -32,7 +33,7 @@ public class CombinationCommentController {
             @Parameter(name = "page", description = "특정 오늘의 조합의  댓글 목록 페이지 번호, query string 입니다.")
     })
     @GetMapping("/{combinationId}")
-    public ApiResponse<CommentPreViewResult> getCombinationComments(@PathVariable(name = "combinationId") Long combinationId,
+    public ApiResponse<CommentPreViewResult> getCombinationComments(@ExistCombination @PathVariable(name = "combinationId") Long combinationId,
                                                                     @CheckPage @RequestParam(name = "page") Integer page) {
 
         return ApiResponse.onSuccess(combinationCommentQueryService.getCommentsFromCombination(combinationId, page));

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/controller/CombinationCommentController.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/controller/CombinationCommentController.java
@@ -2,12 +2,14 @@ package com.example.dgbackend.domain.combinationcomment.controller;
 
 import com.example.dgbackend.domain.combinationcomment.service.CombinationCommentQueryService;
 import com.example.dgbackend.global.common.response.ApiResponse;
+import com.example.dgbackend.global.validation.annotation.CheckPage;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentPreViewResult;
@@ -15,6 +17,7 @@ import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCom
 @Tag(name = "오늘의 조합 댓글 관련 API")
 @RestController
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/combination-comments")
 public class CombinationCommentController {
 
@@ -30,7 +33,7 @@ public class CombinationCommentController {
     })
     @GetMapping("/{combinationId}")
     public ApiResponse<CommentPreViewResult> getCombinationComments(@PathVariable(name = "combinationId") Long combinationId,
-                                                                    @RequestParam(name = "page") Integer page) {
+                                                                    @CheckPage @RequestParam(name = "page") Integer page) {
 
         return ApiResponse.onSuccess(combinationCommentQueryService.getCommentsFromCombination(combinationId, page));
     }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/dto/CombinationCommentResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/dto/CombinationCommentResponse.java
@@ -7,19 +7,22 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class CombinationCommentResponse {
 
     /**
-     * 오늘의 조합에 작성된 댓글 조회
+     * 오늘의 조합에 작성된 댓글 페이징 조회
      */
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
-    public static class CombinationCommentResult {
-        List<CombinationCommentPreviewResult> combinationCommentList;
+    public static class CommentPreViewResult {
+        List<CommentResult> combinationCommentList;
         Integer listSize;
         Integer totalPage;
         Long totalElements;
@@ -27,37 +30,68 @@ public class CombinationCommentResponse {
         Boolean isLast;
     }
 
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Getter
-    public static class CombinationCommentPreviewResult {
-        Long combinationCommentId;
-        String content;
-        Long parentId;
-    }
+    public static CommentPreViewResult toCommentPreViewResult(Page<CombinationComment> comments) {
 
-    public static CombinationCommentPreviewResult toCommentPreviewResult(CombinationComment comment) {
-        return CombinationCommentPreviewResult.builder()
-                .combinationCommentId(comment.getId())
-                .content(comment.getContent())
-                .parentId(comment.getParentId())
-                .build();
-    }
-
-    public static CombinationCommentResult toCombinationCommentResult(Page<CombinationComment> comments) {
-
-        List<CombinationCommentPreviewResult> commentPreviewDTOS = comments.stream()
-                .map(CombinationCommentResponse::toCommentPreviewResult)
+        List<CommentResult> commentPreviewList = comments.stream()
+                .filter(commet -> commet.getParentComment() == null)
+                .map(CombinationCommentResponse::toCommentResult)
                 .toList();
 
-        return CombinationCommentResult.builder()
-                .combinationCommentList(commentPreviewDTOS)
-                .listSize(commentPreviewDTOS.size())
+        return CommentPreViewResult.builder()
+                .combinationCommentList(commentPreviewList)
+                .listSize(commentPreviewList.size())
                 .totalPage(comments.getTotalPages())
                 .totalElements(comments.getTotalElements())
                 .isFirst(comments.isFirst())
                 .isLast(comments.isLast())
                 .build();
+    }
+
+    /**
+     * 오늘의 조합 댓글 DTO
+     */
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class CommentResult {
+
+        private Long id;
+        private String content;
+        private String memberName;
+        private LocalDateTime updatedAt; // 댓글 생성 및 수정 시간
+        private Integer childCount;
+        private List<CommentResult> childComments = new ArrayList<>();
+    }
+
+    public static CommentResult toCommentResult(CombinationComment combinationComment) {
+
+        return CommentResult.builder()
+                .id(combinationComment.getId())
+                .content(combinationComment.getContent())
+                .memberName(combinationComment.getMember().getName())
+                .updatedAt(combinationComment.getUpdatedAt())
+                .childCount(getChildCount(combinationComment))
+                .childComments(getChildComments(combinationComment))
+                .build();
+    }
+
+    private static List<CommentResult> getChildComments(CombinationComment combinationComment) {
+
+        return Optional.ofNullable(combinationComment.getChildComments())
+                .orElse(new ArrayList<>()) // 자식 댓글 없는 경우
+                .stream()
+                .filter(CombinationComment::isState) // 존재하는 댓글만 필터링
+                .map(CombinationCommentResponse::toCommentResult)
+                .toList();
+    }
+
+    private static Integer getChildCount(CombinationComment combinationComment) {
+
+        return Optional.ofNullable(combinationComment.getChildComments())
+                .map(childComments -> (int) childComments.stream()
+                        .filter(CombinationComment::isState)
+                        .count())
+                .orElse(null);
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/repository/CombinationCommentRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/repository/CombinationCommentRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CombinationCommentRepository extends JpaRepository<CombinationComment, Long> {
 
-    Page<CombinationComment> findAllByCombination(Combination combination, Pageable pageable);
+    Page<CombinationComment> findAllByCombinationId(Long combinationId, Pageable pageable);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentQueryService.java
@@ -1,11 +1,8 @@
 package com.example.dgbackend.domain.combinationcomment.service;
 
-import com.example.dgbackend.domain.combination.Combination;
-import com.example.dgbackend.domain.combinationcomment.CombinationComment;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
+import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentPreViewResult;
 
 public interface CombinationCommentQueryService {
 
-    Page<CombinationComment> getCombinationCommentFromCombination(Combination combination, PageRequest pageRequest);
+    CommentPreViewResult getCommentsFromCombination(Long combinationId, Integer page);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentQueryServiceImpl.java
@@ -1,13 +1,13 @@
 package com.example.dgbackend.domain.combinationcomment.service;
 
-import com.example.dgbackend.domain.combination.Combination;
-import com.example.dgbackend.domain.combinationcomment.CombinationComment;
 import com.example.dgbackend.domain.combinationcomment.repository.CombinationCommentRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentPreViewResult;
+import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.toCommentPreViewResult;
 
 @Service
 @Transactional(readOnly = true)
@@ -17,9 +17,8 @@ public class CombinationCommentQueryServiceImpl implements CombinationCommentQue
     private final CombinationCommentRepository combinationCommentRepository;
 
     @Override
-    public Page<CombinationComment> getCombinationCommentFromCombination(Combination combination,
-                                                                         PageRequest pageRequest) {
+    public CommentPreViewResult getCommentsFromCombination(Long combinationId, Integer page) {
 
-        return combinationCommentRepository.findAllByCombination(combination, pageRequest);
+        return toCommentPreViewResult(combinationCommentRepository.findAllByCombinationId(combinationId, PageRequest.of(page, 10)));
     }
 }

--- a/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
@@ -30,6 +30,9 @@ public enum ErrorStatus implements BaseErrorCode {
     //S3 관련
     _S3_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "S3_001", "S3에 존재하지 않는 이미지입니다"),
 
+    //Paging 관련
+    _PAGE_RANGE_ERROR(HttpStatus.BAD_REQUEST, "PAGE_001", "적절한 페이지 번호가 아닙니다."),
+
     //인증 관련
     _EMPTY_JWT(HttpStatus.UNAUTHORIZED, "AUTH_001", "JWT가 존재하지 않습니다."),
     _INVALID_JWT(HttpStatus.UNAUTHORIZED, "AUTH_002", "유효하지 않은 JWT입니다."),

--- a/src/main/java/com/example/dgbackend/global/validation/annotation/CheckPage.java
+++ b/src/main/java/com/example/dgbackend/global/validation/annotation/CheckPage.java
@@ -1,0 +1,18 @@
+package com.example.dgbackend.global.validation.annotation;
+
+import com.example.dgbackend.global.validation.validator.PageCheckValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = PageCheckValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckPage {
+
+    String message() default "적절한 Page 번호가 아닙니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/example/dgbackend/global/validation/annotation/ExistCombination.java
+++ b/src/main/java/com/example/dgbackend/global/validation/annotation/ExistCombination.java
@@ -1,0 +1,20 @@
+package com.example.dgbackend.global.validation.annotation;
+
+import com.example.dgbackend.global.validation.validator.CombinationExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = CombinationExistValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistCombination {
+
+    String message() default "존재하지 않는 오늘의 조합 게시글 입니다..";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/example/dgbackend/global/validation/validator/CombinationExistValidator.java
+++ b/src/main/java/com/example/dgbackend/global/validation/validator/CombinationExistValidator.java
@@ -1,0 +1,34 @@
+package com.example.dgbackend.global.validation.validator;
+
+import com.example.dgbackend.domain.combination.service.CombinationQueryService;
+import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
+import com.example.dgbackend.global.validation.annotation.ExistCombination;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CombinationExistValidator implements ConstraintValidator<ExistCombination, Long> {
+
+    private final CombinationQueryService combinationQueryService;
+
+    @Override
+    public void initialize(ExistCombination constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long combinationId, ConstraintValidatorContext context) {
+
+        boolean valid = combinationQueryService.existCombination(combinationId);
+
+        if (!valid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus._COMBINATION_NOT_FOUND.toString()).addConstraintViolation();
+        }
+        return valid;
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/global/validation/validator/PageCheckValidator.java
+++ b/src/main/java/com/example/dgbackend/global/validation/validator/PageCheckValidator.java
@@ -1,0 +1,26 @@
+package com.example.dgbackend.global.validation.validator;
+
+import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
+import com.example.dgbackend.global.validation.annotation.CheckPage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PageCheckValidator implements ConstraintValidator<CheckPage, Integer> {
+
+    @Override
+    public void initialize(CheckPage constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Integer page, ConstraintValidatorContext context) {
+        if (page < 0) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus._PAGE_RANGE_ERROR.toString()).addConstraintViolation();
+            return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## 요약

- 특정 오늘의 조합에 작성된 댓글을 페이징하여 조회하는 API입니다.

## 상세 내용

- 오늘의 조합에 작성된 댓글을 조회할 때 부모 댓글과 자식 댓글을 반환합니다.

## 질문 및 이외 사항

1. 실행 결과
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/5a87713a-6cb2-4f58-bdb6-6afb34ba222a)


2. Page Validator 실행 결과 (현재는 page 번호 시작을 0으로 설정해두었습니다.)
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/183cfeb0-ad76-45f9-a5fd-103cc3e471a4)


3. Combination Validator 실행결과
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/c27c6347-f189-4288-9761-11263f953b6a)


## 이슈 번호

- close #57 