### PR TITLE
FIX : 오늘의 조합 상세 조회에 CombinationImage, CombinationLike 정보 추가 전달

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationResponse.java
@@ -123,6 +123,7 @@ public class CombinationResponse {
         String title;
         String content;
         List<String> hashTagList;
+        List<String> combinationImageList;
     }
 
     public static CombinationResult toCombinationResult(Combination combination,
@@ -131,11 +132,16 @@ public class CombinationResponse {
                 .map(hto -> hto.getHashTag().getName())
                 .toList();
 
+        List<String> imageList = combination.getCombinationImages().stream()
+                .map(CombinationImage::getImageUrl)
+                .toList();
+
         return CombinationResult.builder()
                 .combinationId(combination.getId())
                 .title(combination.getTitle())
                 .content(combination.getContent())
                 .hashTagList(hashTagList)
+                .combinationImageList(imageList)
                 .build();
     }
 

--- a/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationResponse.java
@@ -67,7 +67,7 @@ public class CombinationResponse {
     // Combination -> CombinationPreviewDTO로 변환
     public static CombinationPreviewResult toCombinationPreviewResult(Combination combination,
                                                                       List<List<HashTagOption>> hashTagOptions) {
-        // TODO: 대표 이지미 정하기
+        // TODO: 대표 이미지 정하기
         String imageUrl = combination.getCombinationImages()
                 .stream()
                 .findFirst()
@@ -124,10 +124,12 @@ public class CombinationResponse {
         String content;
         List<String> hashTagList;
         List<String> combinationImageList;
+        Boolean isCombinationLike;
     }
 
     public static CombinationResult toCombinationResult(Combination combination,
-                                                        List<HashTagOption> hashTagOptions) {
+                                                        List<HashTagOption> hashTagOptions,
+                                                        boolean isCombinationLike) {
         List<String> hashTagList = hashTagOptions.stream()
                 .map(hto -> hto.getHashTag().getName())
                 .toList();
@@ -142,6 +144,7 @@ public class CombinationResponse {
                 .content(combination.getContent())
                 .hashTagList(hashTagList)
                 .combinationImageList(imageList)
+                .isCombinationLike(isCombinationLike)
                 .build();
     }
 

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -7,10 +7,12 @@ import com.example.dgbackend.domain.combinationcomment.CombinationComment;
 import com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse;
 import com.example.dgbackend.domain.combinationcomment.service.CombinationCommentQueryService;
 import com.example.dgbackend.domain.combinationimage.CombinationImage;
+import com.example.dgbackend.domain.combinationlike.service.CombinationLikeQueryService;
 import com.example.dgbackend.domain.hashtagoption.HashTagOption;
 import com.example.dgbackend.domain.hashtagoption.repository.HashTagOptionRepository;
 import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.member.dto.MemberResponse;
+import com.example.dgbackend.domain.member.repository.MemberRepository;
 import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
 import com.example.dgbackend.global.exception.ApiException;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +35,8 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
     private final CombinationRepository combinationRepository;
     private final HashTagOptionRepository hashTagOptionRepository;
     private final CombinationCommentQueryService combinationCommentQueryService;
+    private final MemberRepository memberRepository;
+    private final CombinationLikeQueryService combinationLikeQueryService;
 
     /*
     오늘의 조합 홈 조회(페이징)
@@ -60,11 +64,17 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
                 () -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND)
         );
 
+        // TODO : Login Member 추후에 Token을 통해 정보 얻기
+        Member loginMember = memberRepository.findById(1L).get();
+
+        // CombinationLike
+        boolean isCombinationLike = combinationLikeQueryService.isCombinationLike(combination, loginMember);
+
         // HashTagOption
         List<HashTagOption> hashTagOptions = hashTagOptionRepository.findAllByCombinationWithFetch(combination);
-        CombinationResult combinationResult = toCombinationResult(combination, hashTagOptions);
+        CombinationResult combinationResult = toCombinationResult(combination, hashTagOptions, isCombinationLike);
 
-        // Member
+        // Member - 작성자
         Member member = combination.getMember();
         MemberResponse.MemberResult memberResult = toMemberResult(member);
 

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -60,6 +60,7 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
                 () -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND)
         );
 
+        // HashTagOption
         List<HashTagOption> hashTagOptions = hashTagOptionRepository.findAllByCombinationWithFetch(combination);
         CombinationResult combinationResult = toCombinationResult(combination, hashTagOptions);
 

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/repository/CombinationLikeRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/repository/CombinationLikeRepository.java
@@ -1,9 +1,13 @@
 package com.example.dgbackend.domain.combinationlike.repository;
 
+import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.combinationlike.CombinationLike;
+import com.example.dgbackend.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CombinationLikeRepository extends JpaRepository<CombinationLike, Long> {
 
     void deleteByCombinationId(Long combinationId);
+
+    boolean existsByCombinationAndMember(Combination combination, Member member);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryService.java
@@ -1,0 +1,9 @@
+package com.example.dgbackend.domain.combinationlike.service;
+
+import com.example.dgbackend.domain.combination.Combination;
+import com.example.dgbackend.domain.member.Member;
+
+public interface CombinationLikeQueryService {
+
+    boolean isCombinationLike(Combination combination, Member member);
+}

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
@@ -1,0 +1,22 @@
+package com.example.dgbackend.domain.combinationlike.service;
+
+import com.example.dgbackend.domain.combination.Combination;
+import com.example.dgbackend.domain.combinationlike.repository.CombinationLikeRepository;
+import com.example.dgbackend.domain.member.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryService {
+
+    private final CombinationLikeRepository combinationLikeRepository;
+
+    @Override
+    public boolean isCombinationLike(Combination combination, Member member) {
+
+        return combinationLikeRepository.existsByCombinationAndMember(combination, member);
+    }
+}

--- a/src/main/java/com/example/dgbackend/domain/member/Member.java
+++ b/src/main/java/com/example/dgbackend/domain/member/Member.java
@@ -6,11 +6,9 @@ import com.example.dgbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+@Builder
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)


### PR DESCRIPTION
## 요약

- 오늘의 조합 상세 조회 시 CombinationImage 정보 같이 전달하기
- 특정 오늘의 조합에 좋아요 상태 여부 전달하기

## 상세 내용

- 오늘의 조합 상세 조회 시 보여지는 Image 데이터 추가 전달하기
- 로그인 사용자가 특정 오늘의 조합에 좋아요 눌렀는지 확인하는 데이터 추가 전달하기

## 질문 및 이외 사항

-

## 이슈 번호

- close #47 