### PR TITLE
Feat: 오늘의 조합 댓글 수정 API 개발

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -91,6 +91,7 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
     @Override
     public boolean existCombination(Long combinationId) {
         return combinationRepository.existsById(combinationId);
+    }
 
     /*
      * Combination 조회

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/CombinationComment.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/CombinationComment.java
@@ -6,8 +6,6 @@ import com.example.dgbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
-import java.util.ArrayList;
-import java.util.List;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,5 +45,12 @@ public class CombinationComment extends BaseTimeEntity {
     //== 연관관계 관련 메서드 ==//
     public void setCombination(Combination combination) {
         this.combination = combination;
+    }
+
+    /**
+     * Comment Update
+     */
+    public void updateComment(String content) {
+        this.content = content;
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/controller/CombinationCommentController.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/controller/CombinationCommentController.java
@@ -1,6 +1,9 @@
 package com.example.dgbackend.domain.combinationcomment.controller;
 
 
+import com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentRequest;
+import com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse;
+import com.example.dgbackend.domain.combinationcomment.service.CombinationCommentCommandService;
 import com.example.dgbackend.domain.combinationcomment.service.CombinationCommentQueryService;
 import com.example.dgbackend.global.common.response.ApiResponse;
 import com.example.dgbackend.global.validation.annotation.CheckPage;
@@ -15,12 +18,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentPreViewResult;
-
-import com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentRequest;
-import com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse;
-import com.example.dgbackend.domain.combinationcomment.service.CombinationCommentCommandService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
 
 
 @Tag(name = "오늘의 조합 댓글 관련 API")
@@ -59,5 +56,17 @@ public class CombinationCommentController {
 
         // TODO: HttpServletRequest 사용해서 Authorization token으로 사용자 정보 받아오기
         return ApiResponse.onSuccess(combinationCommentCommandService.saveCombinationComment(combinationId, request));
+    }
+
+    @Operation(summary = "오늘의 조합 댓글 수정", description = "오늘의 조합의 댓글을 수정합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 댓글 수정 성공")
+    })
+    @Parameter(name = "commentId", description = "수정하는 댓글 Id, Path Variable 입니다.")
+    @PatchMapping("/{commentId}")
+    public ApiResponse<CombinationCommentResponse.CommentProcResult> updateCombinationComment(@PathVariable(name = "commentId") Long commentId,
+                                                                                              @RequestBody CombinationCommentRequest.UpdateComment request) {
+
+        return ApiResponse.onSuccess(combinationCommentCommandService.updateComment(commentId, request));
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/dto/CombinationCommentRequest.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/dto/CombinationCommentRequest.java
@@ -26,4 +26,12 @@ public class CombinationCommentRequest {
                 .combination(combination)
                 .build();
     }
+
+    @Getter
+    @Schema(name = "오늘의 조합 댓글 수정 요청 DTO")
+    public static class UpdateComment {
+
+        private String content;
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/dto/CombinationCommentResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/dto/CombinationCommentResponse.java
@@ -73,7 +73,8 @@ public class CombinationCommentResponse {
                 .updatedAt(combinationComment.getUpdatedAt())
                 .childCount(getChildCount(combinationComment))
                 .childComments(getChildComments(combinationComment))
-   }
+                .build();
+    }
 
 
     private static List<CommentResult> getChildComments(CombinationComment combinationComment) {
@@ -95,4 +96,23 @@ public class CombinationCommentResponse {
                 .orElse(null);
     }
 
+    /**
+     * 작성, 수정, 삭제 시 응답 DTO
+     */
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class CommentProcResult {
+        Long commentId;
+        LocalDateTime createdAt;
+    }
+
+    public static CombinationCommentResponse.CommentProcResult toCommentProcResult(Long commentId) {
+
+        return CommentProcResult.builder()
+                .commentId(commentId)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentCommandService.java
@@ -15,4 +15,6 @@ public interface CombinationCommentCommandService {
     CombinationComment getParentComment(Long parentId);
 
     CombinationComment getComment(Long commentId);
+
+    CombinationCommentResponse.CommentProcResult updateComment(Long commentId, CombinationCommentRequest.UpdateComment request);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentCommandServiceImpl.java
@@ -3,6 +3,8 @@ package com.example.dgbackend.domain.combinationcomment.service;
 import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.combination.service.CombinationQueryService;
 import com.example.dgbackend.domain.combinationcomment.CombinationComment;
+import com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentRequest;
+import com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse;
 import com.example.dgbackend.domain.combinationcomment.repository.CombinationCommentRepository;
 import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.member.repository.MemberRepository;
@@ -16,8 +18,7 @@ import java.util.Optional;
 
 import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentRequest.WriteComment;
 import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentRequest.toCombinationComment;
-import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentResult;
-import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.toCommentResult;
+import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.*;
 
 @Service
 @Transactional
@@ -74,5 +75,15 @@ public class CombinationCommentCommandServiceImpl implements CombinationCommentC
         return combinationCommentRepository.findById(commentId).orElseThrow(
                 () -> new ApiException(ErrorStatus._COMBINATION_COMMENT_NOT_FOUND)
         );
+    }
+
+    @Override
+    public CombinationCommentResponse.CommentProcResult updateComment(Long commentId, CombinationCommentRequest.UpdateComment request) {
+
+        CombinationComment combinationComment = getComment(commentId);
+
+        combinationComment.updateComment(request.getContent());
+
+        return toCommentProcResult(commentId);
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/member/Member.java
+++ b/src/main/java/com/example/dgbackend/domain/member/Member.java
@@ -13,7 +13,6 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Builder
 public class Member extends BaseTimeEntity {
 
     @Id


### PR DESCRIPTION
## 요약

- 오늘의 조합 댓글 수정 API 개발

## 상세 내용

- 특정 오늘의 조합에 작성된 댓글을 수정하는 API를 구현합니다.

## 질문 및 이외 사항

1. 수정 API 실행결과
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/84cd6e9f-9217-42a0-95a8-7ad7d010afe2)

2. DB 변경 사항 확인
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/c6f97255-83ea-4549-a275-41fecd057fd3)


## 이슈 번호

- close #60 