### PR TITLE
Feat: 추천 삭제 API

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -91,7 +91,7 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
     @Override
     public boolean existCombination(Long combinationId) {
         return combinationRepository.existsById(combinationId);
-
+    }
     /*
      * Combination 조회
      */

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/dto/CombinationCommentResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/dto/CombinationCommentResponse.java
@@ -72,7 +72,7 @@ public class CombinationCommentResponse {
                 .memberName(combinationComment.getMember().getName())
                 .updatedAt(combinationComment.getUpdatedAt())
                 .childCount(getChildCount(combinationComment))
-                .childComments(getChildComments(combinationComment))
+                .childComments(getChildComments(combinationComment)).build();
    }
 
 

--- a/src/main/java/com/example/dgbackend/domain/member/Member.java
+++ b/src/main/java/com/example/dgbackend/domain/member/Member.java
@@ -8,7 +8,6 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
-@Builder
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/example/dgbackend/domain/recommend/controller/RecommendController.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/controller/RecommendController.java
@@ -43,6 +43,17 @@ public class RecommendController {
 
         return ApiResponse.onSuccess(recommendQueryService.getRecommendResult(recommendId));
     }
+
+    @Operation(summary = "오늘의 조합 - 추천 받은 조합 삭제", description = "추천 받은 조합을 선택하여 오늘의 조합을 작성합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "추천 받은 조합 삭제 성공")
+    })
+    @Parameter(name = "recommendId", description = "내가 받은 추천 조합 Id, Path Variable 입니다.")
+    @DeleteMapping("/{recommendId}")
+    public ApiResponse<RecommendResponse.RecommendResult> deleteRecommend(@PathVariable(name = "recommendId") Long recommendId) {
+
+        return ApiResponse.onSuccess(recommendQueryService.deleteRecommend(recommendId));
+    }
 }
 
 

--- a/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendQueryService.java
@@ -8,4 +8,5 @@ public interface RecommendQueryService {
 
     void addRecommend(Member member, RecommendRequest.RecommendRequestDTO recommendRequestDTO, String drinkName, String drinkInfo, String imageUrl);
     RecommendResult getRecommendResult(Long recommendId);
+    RecommendResult deleteRecommend(Long recommendId);          //추천 삭제
 }


### PR DESCRIPTION
## 요약
주류 추천 삭제 API

## 상세 내용
Path variable로 recommend id를 입력받아 해당 추천을 삭제하는 API.
S3의 이미지와 DB에서 recommend 객체를 삭제한다.

## 질문 및 이외 사항
- 추천 생성단계에서 imageUrl을 "temp"로 저장하고 있던 내용을 수정함

## 이슈 번호
- close #63 