### PR TITLE
Feat : 레시피 이미지 API

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/recipeimage/RecipeImage.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/RecipeImage.java
@@ -10,15 +10,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Builder
 public class RecipeImage extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/controller/RecipeImageController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/controller/RecipeImageController.java
@@ -44,4 +44,16 @@ public class RecipeImageController {
         return ApiResponse.onSuccess(recipeImageService.createRecipeImage(recipeImageRequestVO));
     }
 
+    @Operation(summary = "레시피 이미지 수정", description = "레시피 이미지 수정")
+    @Parameter(name = "recipeId", description = "레시피 id", required = true)
+    @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<RecipeImageResponse> updateRecipeImage(@RequestPart(value = "file", required = false) @Parameter(name = "file", description = "파일", required = false) List<MultipartFile> file,
+                                                              @RequestPart(value = "deleteList", required = false) @Parameter(name = "deleteList", description = "삭제할 파일 url 리스트", required = false) List<String> deleteFileUrlStringList,
+                                                              @RequestParam("recipeId") Long recipeId) {
+
+        //파일과 레시피 id, 삭제할 파일 url 리스트로 RecipeImageVO.FileRecipe 생성
+        RecipeImageVO.FileVO recipeImageRequestVO = RecipeImageVO.FileVO.of(file, recipeId, deleteFileUrlStringList);
+        return ApiResponse.onSuccess(recipeImageService.updateRecipeImage(recipeImageRequestVO));
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/controller/RecipeImageController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/controller/RecipeImageController.java
@@ -1,5 +1,7 @@
 package com.example.dgbackend.domain.recipeimage.controller;
 
+import com.example.dgbackend.domain.recipeimage.dto.RecipeImageResponse;
+import com.example.dgbackend.domain.recipeimage.dto.RecipeImageVO;
 import com.example.dgbackend.domain.recipeimage.service.RecipeImageService;
 import com.example.dgbackend.global.common.response.ApiResponse;
 import com.example.dgbackend.global.s3.S3Service;
@@ -8,10 +10,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -30,6 +31,17 @@ public class RecipeImageController {
     @GetMapping
     public ApiResponse<List<String>> getRecipeImages(@RequestParam("recipeId") Long recipeId) {
         return ApiResponse.onSuccess(recipeImageService.getRecipeImages(recipeId));
+    }
+
+    @Operation(summary = "레시피 이미지 생성", description = "레시피 이미지 생성")
+    @Parameter(name = "file", description = "파일", required = true)
+    @Parameter(name = "recipeId", description = "레시피 id", required = true)
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<RecipeImageResponse> createRecipeImage(@RequestPart("file") List<MultipartFile> file, @RequestParam("recipeId") Long recipeId) {
+
+        //파일과 레시피 id로 RecipeImageVO.FileRecipe 생성
+        RecipeImageVO.FileVO recipeImageRequestVO = RecipeImageVO.FileVO.of(file, recipeId, null);
+        return ApiResponse.onSuccess(recipeImageService.createRecipeImage(recipeImageRequestVO));
     }
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/controller/RecipeImageController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/controller/RecipeImageController.java
@@ -56,4 +56,12 @@ public class RecipeImageController {
         return ApiResponse.onSuccess(recipeImageService.updateRecipeImage(recipeImageRequestVO));
     }
 
+    @Operation
+    @Parameter(name = "recipeId", description = "레시피 id", required = true)
+    @DeleteMapping
+    public ApiResponse<String> deleteRecipeImage(@RequestParam("recipeId") Long recipeId) {
+        recipeImageService.deleteAllRecipeImage(recipeId);
+        return ApiResponse.onSuccess("삭제 성공");
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/controller/RecipeImageController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/controller/RecipeImageController.java
@@ -1,0 +1,35 @@
+package com.example.dgbackend.domain.recipeimage.controller;
+
+import com.example.dgbackend.domain.recipeimage.service.RecipeImageService;
+import com.example.dgbackend.global.common.response.ApiResponse;
+import com.example.dgbackend.global.s3.S3Service;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "레시피 이미지 API", description = "레시피 이미지 API")
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/recipe-images")
+public class RecipeImageController {
+
+    private final S3Service s3Service;
+    private final RecipeImageService recipeImageService;
+
+    @Operation(summary = "레시피 이미지 조회", description = "레시피 이미지 조회")
+    @Parameter(name = "recipeId", description = "레시피 id", required = true)
+    @GetMapping
+    public ApiResponse<List<String>> getRecipeImages(@RequestParam("recipeId") Long recipeId) {
+        return ApiResponse.onSuccess(recipeImageService.getRecipeImages(recipeId));
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/dto/RecipeImageRequest.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/dto/RecipeImageRequest.java
@@ -1,0 +1,21 @@
+package com.example.dgbackend.domain.recipeimage.dto;
+
+import com.example.dgbackend.domain.recipe.Recipe;
+import com.example.dgbackend.domain.recipeimage.RecipeImage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class RecipeImageRequest {
+
+    public static RecipeImage toEntity(Recipe recipe, String imageUrl) {
+        return RecipeImage.builder()
+                .recipe(recipe)
+                .imageUrl(imageUrl)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/dto/RecipeImageResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/dto/RecipeImageResponse.java
@@ -1,0 +1,30 @@
+package com.example.dgbackend.domain.recipeimage.dto;
+
+import com.example.dgbackend.domain.recipe.dto.RecipeResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecipeImageResponse {
+
+    @Schema(description = "레시피 정보")
+    private RecipeResponse recipe;
+
+    @Schema(description = "레시피 이미지 url 리스트", example = "[\"https://d3h9ln6psucegz.cloudfront.net/images/recipe/recipe_1/recipe_1_1.jpg\"]")
+    private List<String> imageUrlList;
+
+    public static RecipeImageResponse toResponse(RecipeResponse recipe, List<String> imageUrlList) {
+        return RecipeImageResponse.builder()
+                .recipe(recipe)
+                .imageUrlList(imageUrlList)
+                .build();
+    }
+}

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/dto/RecipeImageVO.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/dto/RecipeImageVO.java
@@ -1,0 +1,31 @@
+package com.example.dgbackend.domain.recipeimage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public class RecipeImageVO {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class FileVO {
+        private Long recipeId;
+        private List<MultipartFile> fileList;
+        private List<String> deleteFileUrlList;
+
+        public static FileVO of(List<MultipartFile> fileList, Long recipeId, List<String> deleteFileUrlList) {
+            return FileVO.builder()
+                    .fileList(fileList)
+                    .recipeId(recipeId)
+                    .deleteFileUrlList(deleteFileUrlList)
+                    .build();
+        }
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/repository/RecipeImageRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/repository/RecipeImageRepository.java
@@ -1,0 +1,10 @@
+package com.example.dgbackend.domain.recipeimage.repository;
+
+import com.example.dgbackend.domain.recipeimage.RecipeImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RecipeImageRepository extends JpaRepository<RecipeImage, Long> {
+    List<RecipeImage> findAllByRecipeId(Long recipeId);
+}

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/repository/RecipeImageRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/repository/RecipeImageRepository.java
@@ -4,7 +4,11 @@ import com.example.dgbackend.domain.recipeimage.RecipeImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
-public interface RecipeImageRepository extends JpaRepository<RecipeImage, Long> {
+public interface RecipeImageRepository extends JpaRepository<RecipeImage,Long> {
+
     List<RecipeImage> findAllByRecipeId(Long recipeId);
+
+    Optional<RecipeImage> findByImageUrl(String imageUrl);
 }

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
@@ -69,6 +69,30 @@ public class RecipeImageService {
         return request;
     }
 
+    @Transactional
+    public RecipeImageResponse updateRecipeImage(RecipeImageVO.FileVO request) {
+        Recipe recipe = recipeService.getRecipe(request.getRecipeId());
+
+        //새로운 이미지 업로드
+        if (request.getFileList() != null && !request.getFileList().isEmpty()) {
+            createRecipeImage(request);
+        }
+
+        List<String> deleteFileUrlList = request.getDeleteFileUrlList();
+
+        //삭제 요청 이미지 삭제
+        if (deleteFileUrlList != null && !deleteFileUrlList.isEmpty()) {
+            deleteFileUrlList.forEach(
+                    deleteFileUrl -> {
+                        deleteRecipeImage(deleteFileUrl);
+                        s3Service.deleteFile(deleteFileUrl);
+                    }
+            );
+        }
+
+        return RecipeImageResponse.toResponse(RecipeResponse.toResponse(recipe), getRecipeImages(recipe.getId()));
+    }
+
     //recipeImageRepository에서 imageUrl로 조회해서 있으면 삭제하고 s3에서도 삭제
     //없다면 예외처리
     public void deleteRecipeImage(String imageUrl) {

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
@@ -106,4 +106,10 @@ public class RecipeImageService {
                         });
     }
 
+    public void deleteAllRecipeImage(Long recipeId) {
+        recipeImageRepository.findAllByRecipeId(recipeId).forEach(recipeImageEntity -> {
+            deleteRecipeImage(recipeImageEntity.getImageUrl());
+        });
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
@@ -1,12 +1,22 @@
 package com.example.dgbackend.domain.recipeimage.service;
 
+import com.example.dgbackend.domain.recipe.Recipe;
+import com.example.dgbackend.domain.recipe.dto.RecipeResponse;
 import com.example.dgbackend.domain.recipe.service.RecipeService;
 import com.example.dgbackend.domain.recipeimage.RecipeImage;
+import com.example.dgbackend.domain.recipeimage.dto.RecipeImageRequest;
+import com.example.dgbackend.domain.recipeimage.dto.RecipeImageResponse;
+import com.example.dgbackend.domain.recipeimage.dto.RecipeImageVO;
 import com.example.dgbackend.domain.recipeimage.repository.RecipeImageRepository;
+import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
+import com.example.dgbackend.global.exception.ApiException;
 import com.example.dgbackend.global.s3.S3Service;
+import com.example.dgbackend.global.s3.dto.S3Result;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -24,6 +34,16 @@ public class RecipeImageService {
         return recipeImageRepository.findAllByRecipeId(recipeId).stream()
                 .map(RecipeImage::getImageUrl)
                 .toList();
+    }
+
+    //파일 없을 시 예외처리
+    private List<MultipartFile> validFileList(List<MultipartFile> request) {
+
+        if (request == null || request.isEmpty()) {
+            throw new ApiException(ErrorStatus._NOTHING_RECIPE_IMAGE);
+        }
+
+        return request;
     }
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
@@ -69,4 +69,17 @@ public class RecipeImageService {
         return request;
     }
 
+    //recipeImageRepository에서 imageUrl로 조회해서 있으면 삭제하고 s3에서도 삭제
+    //없다면 예외처리
+    public void deleteRecipeImage(String imageUrl) {
+        recipeImageRepository.findByImageUrl(imageUrl)
+                .ifPresentOrElse(recipeImageEntity -> {
+                            recipeImageRepository.delete(recipeImageEntity);
+                            s3Service.deleteFile(recipeImageEntity.getImageUrl());
+                        },
+                        () -> {
+                            throw new ApiException(ErrorStatus._NOTHING_RECIPE_IMAGE);
+                        });
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
@@ -102,7 +102,7 @@ public class RecipeImageService {
                             s3Service.deleteFile(recipeImageEntity.getImageUrl());
                         },
                         () -> {
-                            throw new ApiException(ErrorStatus._NOTHING_RECIPE_IMAGE);
+                            throw new ApiException(ErrorStatus._EMPTY_RECIPE_IMAGE);
                         });
     }
 

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
@@ -1,0 +1,29 @@
+package com.example.dgbackend.domain.recipeimage.service;
+
+import com.example.dgbackend.domain.recipe.service.RecipeService;
+import com.example.dgbackend.domain.recipeimage.RecipeImage;
+import com.example.dgbackend.domain.recipeimage.repository.RecipeImageRepository;
+import com.example.dgbackend.global.s3.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class RecipeImageService {
+
+    private final RecipeImageRepository recipeImageRepository;
+    private final RecipeService recipeService;
+
+    private final S3Service s3Service;
+
+    public List<String> getRecipeImages(Long recipeId) {
+        return recipeImageRepository.findAllByRecipeId(recipeId).stream()
+                .map(RecipeImage::getImageUrl)
+                .toList();
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
@@ -41,7 +41,11 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //레시피 댓글
     _EMPTY_RECIPE_COMMENT(HttpStatus.CONFLICT, "RECIPE_COMMENT_001", "존재하지 않는 레시피 댓글입니다."),
-    _OVER_DEPTH_RECIPE_COMMENT(HttpStatus.BAD_REQUEST, "RECIPE_COMMENT_003", "대댓글까지만 가능합니다.");
+    _OVER_DEPTH_RECIPE_COMMENT(HttpStatus.BAD_REQUEST, "RECIPE_COMMENT_003", "대댓글까지만 가능합니다."),
+
+    //레시피 이미지
+    _EMPTY_RECIPE_IMAGE(HttpStatus.CONFLICT, "RECIPE_IMAGE_001", "존재하지 않는 레시피 이미지입니다."),
+    _NOTHING_RECIPE_IMAGE(HttpStatus.BAD_REQUEST, "RECIPE_IMAGE_001", "레시피 이미지가 없습니다.");
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 요약

- Recipe-Imges API 

## 상세 내용

- 기본적인 DTO 추가하였습니다
- POST와 PATCH 시 같은 VO를 사용했습니다. 해당 VO의 변수 입니다.
    - RecipeId
    - fileList (추가할 이미지)
    - deleteFileUrlList (삭제할 이미지 url, 생성시에는 null)

- RecipeImageService의 createRecipeImage 에서 s3에서 Transaction 적용이 되지 않아
Entity save 진행 후 s3 save를  진행해야 하는데 로직 순서가 꼬여 구현 먼저 하였습니다.
이 부분 추후 최우선으로 수정하도록 하겠습니다

- API 목록
    - (GET) /recipe-images?recipeId : 해당 레시피의 모든 이미지 url 조회
    - (POST) /recipe-images?recipeId : 해당 레시피에 이미지 등록
    - (PATCH) /recipe-images?recipeId : 레시피 이미지 수정
    - (DELETE) /recipe-images?recipeId : 레시피 이미지 삭제 

### Postman 테스트

#### 레시피 이미지 등록
<img width="955" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/382ce3a2-60f0-45ff-90d4-20c232c7d981">

#### 레시피 이미지 등록
<img width="958" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/53c0015b-bed7-4d6b-a5e7-c79dc1c693e5">

#### 레시피 수정

- 🚩 특정 이미지들만 삭제
<img width="954" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/72fd045e-ee71-407d-a6eb-9844e8622e94">

- 🚩 이미지 추가
<img width="952" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/6a2a5003-f0cc-4b3f-8f2b-fe903b39f506">

- 🚩 특정 이미지들만 삭제 & 이미지 추가
<img width="951" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/9e9b8314-be94-4fc3-a3aa-cbe7beead278">

#### 레시피 삭제 
<img width="960" alt="스크린샷 2024-01-20 002351" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/ba747c02-d6a1-4ce5-8ffd-d70a441cdeef">

---

#### 예외

- 유효하지 않은 이미지 url
<img width="960" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/699dd736-a0a7-4826-b6e8-db298ae7cb00">

## 질문 및 이외 사항

## 이슈 번호

- Close  #53 