### PR TITLE
Feat: 주간 베스트 조합 조회 API

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
@@ -11,11 +11,18 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
-
-import java.io.IOException;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "오늘의 조합 API")
 @RestController
@@ -29,67 +36,88 @@ public class CombinationController {
 
     @Operation(summary = "오늘의 조합 홈 조회", description = "오늘의 조합 목록을 조회합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 목록 조회 성공")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 목록 조회 성공")
     })
     @Parameter(name = "page", description = "오늘의 조합 목록 페이지 번호, query string 입니다.")
     @GetMapping("")
-    public ApiResponse<CombinationResponse.CombinationPreviewResultList> getCombinations(@CheckPage @RequestParam(name = "page") Integer page) {
+    public ApiResponse<CombinationResponse.CombinationPreviewResultList> getCombinations(
+        @CheckPage @RequestParam(name = "page") Integer page) {
         return ApiResponse.onSuccess(combinationQueryService.getCombinationPreviewResultList(page));
     }
 
     @Operation(summary = "오늘의 조합 상세정보 조회", description = "특정 오늘의 조합 정보를 조회합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 상세정보 조회 성공")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 상세정보 조회 성공")
     })
     @Parameter(name = "combinationId", description = "오늘의 조합 Id, Path Variable 입니다.")
     @GetMapping("/{combinationId}")
-    public ApiResponse<CombinationResponse.CombinationDetailResult> getDetailCombination(@ExistCombination @PathVariable(name = "combinationId") Long combinationId) {
-        return ApiResponse.onSuccess(combinationQueryService.getCombinationDetailResult(combinationId));
+    public ApiResponse<CombinationResponse.CombinationDetailResult> getDetailCombination(
+        @ExistCombination @PathVariable(name = "combinationId") Long combinationId) {
+        return ApiResponse.onSuccess(
+            combinationQueryService.getCombinationDetailResult(combinationId));
     }
 
     @Operation(summary = "오늘의 조합 작성", description = "오늘의 조합 작성합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 작성 성공")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 작성 성공")
     })
     @Parameter(name = "recommendId", description = "내가 받은 추천 조합 Id, Path Variable 입니다.")
     @PostMapping("/recommends/{recommendId}")
-    public ApiResponse<CombinationResponse.CombinationProcResult> writeCombination(@PathVariable(name = "recommendId") Long recommendId,
-                                                                                   @RequestPart(name = "writeCombination") CombinationRequest.WriteCombination request) throws IOException {
+    public ApiResponse<CombinationResponse.CombinationProcResult> writeCombination(
+        @PathVariable(name = "recommendId") Long recommendId,
+        @RequestPart(name = "writeCombination") CombinationRequest.WriteCombination request)
+        throws IOException {
         // TODO: HttpServletRequest 사용해서 Authorization token으로 사용자 정보 받아오기
-        return ApiResponse.onSuccess(combinationCommandService.uploadCombination(recommendId, request));
+        return ApiResponse.onSuccess(
+            combinationCommandService.uploadCombination(recommendId, request));
 
     }
 
 
     @Operation(summary = "오늘의 조합 수정정보 조회", description = "특정 오늘의 조합의 수정할 정보를 조회합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 수정 정보 조회 성공")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 수정 정보 조회 성공")
     })
     @Parameter(name = "combinationId", description = "오늘의 조합 Id, Path Variable 입니다.")
     @GetMapping("/{combinationId}/edit")
-    public ApiResponse<CombinationResponse.CombinationEditResult> editCombination(@ExistCombination @PathVariable(name = "combinationId") Long combinationId) {
-        return ApiResponse.onSuccess(combinationQueryService.getCombinationEditResult(combinationId));
+    public ApiResponse<CombinationResponse.CombinationEditResult> editCombination(
+        @ExistCombination @PathVariable(name = "combinationId") Long combinationId) {
+        return ApiResponse.onSuccess(
+            combinationQueryService.getCombinationEditResult(combinationId));
     }
 
     @Operation(summary = "오늘의 조합 수정", description = "특정 오늘의 조합을 수정합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 수정 성공")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 수정 성공")
     })
     @Parameter(name = "combinationId", description = "오늘의 조합 Id, Path Variable 입니다.")
     @PatchMapping("/{combinationId}")
-    public ApiResponse<CombinationResponse.CombinationProcResult> editProcCombination(@ExistCombination @PathVariable(name = "combinationId") Long combinationId,
-                                                                                      @RequestPart(name = "writeCombination") CombinationRequest.WriteCombination request) throws IOException {
-        return ApiResponse.onSuccess(combinationCommandService.editCombination(combinationId, request));
+    public ApiResponse<CombinationResponse.CombinationProcResult> editProcCombination(
+        @ExistCombination @PathVariable(name = "combinationId") Long combinationId,
+        @RequestPart(name = "writeCombination") CombinationRequest.WriteCombination request)
+        throws IOException {
+        return ApiResponse.onSuccess(
+            combinationCommandService.editCombination(combinationId, request));
     }
 
     @Operation(summary = "오늘의 조합 삭제", description = "특정 오늘의 조합을 삭제합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 삭제 성공")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 삭제 성공")
     })
     @Parameter(name = "combinationId", description = "오늘의 조합 Id, Path Variable 입니다.")
     @DeleteMapping("/{combinationId}")
-    public ApiResponse<CombinationResponse.CombinationProcResult> deleteCombination(@ExistCombination @PathVariable(name = "combinationId") Long combinationId) {
+    public ApiResponse<CombinationResponse.CombinationProcResult> deleteCombination(
+        @ExistCombination @PathVariable(name = "combinationId") Long combinationId) {
 
         return ApiResponse.onSuccess(combinationCommandService.deleteCombination(combinationId));
+    }
+
+    @Operation(summary = "주간 베스트 조합 조회", description = "주간 베스트 조합 목록을 조회합니다.")
+    @Parameter(name = "page", description = "주간 베스트 조합 목록 페이지 번호, query string 입니다.")
+    @GetMapping("/weekly-best")
+    public ApiResponse<CombinationResponse.CombinationPreviewResultList> getWeeklyBestCombinations(
+        @CheckPage @RequestParam(name = "page") Integer page) {
+        return ApiResponse.onSuccess(
+            combinationQueryService.getWeeklyBestCombinationPreviewResultList(page));
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
@@ -1,7 +1,12 @@
 package com.example.dgbackend.domain.combination.repository;
 
 import com.example.dgbackend.domain.combination.Combination;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CombinationRepository extends JpaRepository<Combination, Long> {
+
+    Page<Combination> findCombinationsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
+        Long likeCount, PageRequest pageRequest);
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
@@ -1,8 +1,10 @@
 package com.example.dgbackend.domain.combination.service;
 
-import com.example.dgbackend.domain.combination.Combination;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationDetailResult;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationEditResult;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationPreviewResultList;
 
-import static com.example.dgbackend.domain.combination.dto.CombinationResponse.*;
+import com.example.dgbackend.domain.combination.Combination;
 
 public interface CombinationQueryService {
 
@@ -15,5 +17,7 @@ public interface CombinationQueryService {
     boolean existCombination(Long combinationId);
 
     Combination getCombination(Long combinationId);
+
+    CombinationPreviewResultList getWeeklyBestCombinationPreviewResultList(Integer page);
 
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -1,5 +1,15 @@
 package com.example.dgbackend.domain.combination.service;
 
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationDetailResult;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationEditResult;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationPreviewResultList;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationResult;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.toCombinationDetailResult;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.toCombinationPreviewResultList;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.toCombinationResult;
+import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentPreViewResult;
+import static com.example.dgbackend.domain.member.dto.MemberResponse.toMemberResult;
+
 import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.combination.dto.CombinationResponse;
 import com.example.dgbackend.domain.combination.repository.CombinationRepository;
@@ -11,17 +21,12 @@ import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.member.dto.MemberResponse;
 import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
 import com.example.dgbackend.global.exception.ApiException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-
-import static com.example.dgbackend.domain.combination.dto.CombinationResponse.*;
-import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentPreViewResult;
-import static com.example.dgbackend.domain.member.dto.MemberResponse.toMemberResult;
 
 @Service
 @Transactional(readOnly = true)
@@ -41,8 +46,8 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
 
         List<Combination> combinationList = combinations.getContent();
         List<List<HashTagOption>> hashTagOptionList = combinationList.stream()
-                .map(hashTagOptionRepository::findAllByCombinationWithFetch)
-                .toList();
+            .map(hashTagOptionRepository::findAllByCombinationWithFetch)
+            .toList();
 
         return toCombinationPreviewResultList(combinations, hashTagOptionList);
     }
@@ -55,10 +60,11 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
 
         // Combination
         Combination combination = combinationRepository.findById(combinationId).orElseThrow(
-                () -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND)
+            () -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND)
         );
 
-        List<HashTagOption> hashTagOptions = hashTagOptionRepository.findAllByCombinationWithFetch(combination);
+        List<HashTagOption> hashTagOptions = hashTagOptionRepository.findAllByCombinationWithFetch(
+            combination);
         CombinationResult combinationResult = toCombinationResult(combination, hashTagOptions);
 
         // Member
@@ -66,7 +72,8 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
         MemberResponse.MemberResult memberResult = toMemberResult(member);
 
         // CombinationComment
-        CommentPreViewResult combinationCommentResult = combinationCommentQueryService.getCommentsFromCombination(combinationId, 0);
+        CommentPreViewResult combinationCommentResult = combinationCommentQueryService.getCommentsFromCombination(
+            combinationId, 0);
 
         return toCombinationDetailResult(combinationResult, memberResult, combinationCommentResult);
     }
@@ -78,19 +85,22 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
     public CombinationEditResult getCombinationEditResult(Long combinationId) {
 
         Combination combination = combinationRepository.findById(combinationId).orElseThrow(
-                () -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND)
+            () -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND)
         );
 
         List<CombinationImage> combinationImages = combination.getCombinationImages();
 
-        List<HashTagOption> hashTagOptions = hashTagOptionRepository.findAllByCombinationWithFetch(combination);
+        List<HashTagOption> hashTagOptions = hashTagOptionRepository.findAllByCombinationWithFetch(
+            combination);
 
-        return CombinationResponse.toCombinationEditResult(combination, hashTagOptions, combinationImages);
+        return CombinationResponse.toCombinationEditResult(combination, hashTagOptions,
+            combinationImages);
     }
 
     @Override
     public boolean existCombination(Long combinationId) {
         return combinationRepository.existsById(combinationId);
+    }
 
     /*
      * Combination 조회
@@ -98,7 +108,22 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
     @Override
     public Combination getCombination(Long combinationId) {
         return combinationRepository.findById(combinationId).orElseThrow(
-                () -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND)
+            () -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND)
         );
     }
+
+    @Override
+    public CombinationPreviewResultList getWeeklyBestCombinationPreviewResultList(Integer page) {
+        PageRequest pageRequest = PageRequest.of(page, 10);
+        Page<Combination> combinations = combinationRepository.findCombinationsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
+            10L, pageRequest);
+
+        List<Combination> combinationList = combinations.getContent();
+        List<List<HashTagOption>> hashTagOptionList = combinationList.stream()
+            .map(hashTagOptionRepository::findAllByCombinationWithFetch)
+            .toList();
+
+        return toCombinationPreviewResultList(combinations, hashTagOptionList);
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -116,7 +116,7 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
     public CombinationPreviewResultList getWeeklyBestCombinationPreviewResultList(Integer page) {
         PageRequest pageRequest = PageRequest.of(page, 10);
         Page<Combination> combinations = combinationRepository.findCombinationsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
-            10L, pageRequest);
+            30L, pageRequest);
 
         List<Combination> combinationList = combinations.getContent();
         List<List<HashTagOption>> hashTagOptionList = combinationList.stream()


### PR DESCRIPTION
- Controller, Service, Repository 구현
- 좋아요 10개 이상 게시글 조회

## 요약

- 주간 베스트 조합 조회 API를 구현합니다.

## 상세 내용

- 카일로의 오늘의 조합 조회 API를 참고하여 진행하였습니다.

### CombinationRepository
```java
    Page<Combination> findCombinationsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
        Long likeCount, PageRequest pageRequest);
```
- 해당 메소드를 이용해 넘겨 받은 좋아요 수 이상, 상태가 True 인 게시글들을 받습니다.
- 좋아요 수가 우선이라고 생각하고 진행하였습니다. 또한 좋아요 수는 임시로 10개 이상으로 해놓았는데, 기획에 맞춰 추후 수정하도록 하겠습니다.

### 테스트 결과
- 아래와 같이 게시글 좋아요 수가 10개 이상인 오늘의 조합 글만 조회하도록 하였습니다.
```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "combinationList": [
      {
        "title": "테스트",
        "combinationImageUrl": null,
        "likeCount": 30,
        "commentCount": 0,
        "hashTageList": []
      }
    ],
    "listSize": 1,
    "totalPage": 1,
    "totalElements": 1,
    "isFirst": true,
    "isLast": true
  }
}
```

## 질문 및 이외 사항

- 코딩 컨벤션을 적용하느라 수정된 파일들이 많아지게 됐습니다. 양해 부탁드립니다!
- 다른 분들도 코딩 컨벤션 적용하여 진행해주시면 감사하겠습니다!!
- 또한 카일로가 앞선 #65 PR에서 충돌이 발생하여 실행되지 않는 부분은 충돌이 날까봐 해당 PR에 반영하지 않았습니다.

## 이슈 번호

- close #51 