### PR TITLE
Feat: 오늘의 조합 좋아요 누르기 API

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/Combination.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/Combination.java
@@ -5,15 +5,26 @@ import com.example.dgbackend.domain.combinationcomment.CombinationComment;
 import com.example.dgbackend.domain.combinationimage.CombinationImage;
 import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.global.common.BaseTimeEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Builder
 @Getter
@@ -74,5 +85,16 @@ public class Combination extends BaseTimeEntity {
     public void updateCombination(String title, String content) {
         this.title = title;
         this.content = content;
+    }
+
+    /**
+     * CombinationLike 관련 메서드
+     */
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        this.likeCount--;
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/Combination.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/Combination.java
@@ -75,14 +75,4 @@ public class Combination extends BaseTimeEntity {
         this.title = title;
         this.content = content;
     }
-
-    /**
-     * CombinationLike 관련 메서드
-     */
-    public void increaseLikeCount() {
-        this.likeCount ++;
-    }
-    public void decreaseLikeCount() {
-        this.likeCount --;
-    }
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/Combination.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/Combination.java
@@ -75,4 +75,14 @@ public class Combination extends BaseTimeEntity {
         this.title = title;
         this.content = content;
     }
+
+    /**
+     * CombinationLike 관련 메서드
+     */
+    public void increaseLikeCount() {
+        this.likeCount ++;
+    }
+    public void decreaseLikeCount() {
+        this.likeCount --;
+    }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/CombinationLike.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/CombinationLike.java
@@ -3,7 +3,13 @@ package com.example.dgbackend.domain.combinationlike;
 import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.global.common.BaseTimeEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -29,4 +35,23 @@ public class CombinationLike extends BaseTimeEntity {
     @JoinColumn(name = "combination_id")
     private Combination combination;
 
+    public CombinationLike(Combination combination, Member member) {
+        this.combination = combination;
+        this.member = member;
+        this.combination.increaseLikeCount();
+    }
+
+    public CombinationLike changeState() {
+        this.state = !this.state;
+        if (!this.state) {
+            this.combination.decreaseLikeCount();
+        } else {
+            this.combination.increaseLikeCount();
+        }
+        return this;
+    }
+
+    public Boolean nowCombinationLikeState() {
+        return this.state;
+    }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/CombinationLike.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/CombinationLike.java
@@ -3,13 +3,7 @@ package com.example.dgbackend.domain.combinationlike;
 import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.global.common.BaseTimeEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -35,23 +29,4 @@ public class CombinationLike extends BaseTimeEntity {
     @JoinColumn(name = "combination_id")
     private Combination combination;
 
-    public CombinationLike(Combination combination, Member member) {
-        this.combination = combination;
-        this.member = member;
-        this.combination.increaseLikeCount();
-    }
-
-    public CombinationLike changeState() {
-        this.state = !this.state;
-        if (!this.state) {
-            this.combination.decreaseLikeCount();
-        } else {
-            this.combination.increaseLikeCount();
-        }
-        return this;
-    }
-
-    public Boolean nowCombinationLikeState() {
-        return this.state;
-    }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/controller/CombinationLikeController.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/controller/CombinationLikeController.java
@@ -1,12 +1,8 @@
 package com.example.dgbackend.domain.combinationlike.controller;
 
 
-import com.example.dgbackend.domain.combinationlike.service.CombinationLikeQueryServiceImpl;
-import com.example.dgbackend.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "오늘의 조합 좋아요 관련 API")
@@ -14,14 +10,5 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CombinationLikeController {
 
-    private final CombinationLikeQueryServiceImpl combinationLikeQueryServiceImpl;
 
-
-    @PostMapping("/combination-likes/{memberId}/{combinationId}")
-    public ApiResponse<Boolean> updateCombinationLike(
-        @PathVariable(value = "memberId") Long memberId,
-        @PathVariable(value = "combinationId") Long combinationId) {
-        return ApiResponse.onSuccess(
-            combinationLikeQueryServiceImpl.changeCombinationLike(memberId, combinationId));
-    }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/controller/CombinationLikeController.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/controller/CombinationLikeController.java
@@ -1,8 +1,12 @@
 package com.example.dgbackend.domain.combinationlike.controller;
 
 
+import com.example.dgbackend.domain.combinationlike.service.CombinationLikeQueryServiceImpl;
+import com.example.dgbackend.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "오늘의 조합 좋아요 관련 API")
@@ -10,5 +14,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CombinationLikeController {
 
+    private final CombinationLikeQueryServiceImpl combinationLikeQueryServiceImpl;
 
+
+    @PostMapping("/combination-likes/{memberId}/{combinationId}")
+    public ApiResponse<Boolean> updateCombinationLike(
+        @PathVariable(value = "memberId") Long memberId,
+        @PathVariable(value = "combinationId") Long combinationId) {
+        return ApiResponse.onSuccess(
+            combinationLikeQueryServiceImpl.changeCombinationLike(memberId, combinationId));
+    }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/repository/CombinationLikeRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/repository/CombinationLikeRepository.java
@@ -3,6 +3,7 @@ package com.example.dgbackend.domain.combinationlike.repository;
 import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.combinationlike.CombinationLike;
 import com.example.dgbackend.domain.member.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CombinationLikeRepository extends JpaRepository<CombinationLike, Long> {
@@ -10,4 +11,6 @@ public interface CombinationLikeRepository extends JpaRepository<CombinationLike
     void deleteByCombinationId(Long combinationId);
 
     boolean existsByCombinationAndMember(Combination combination, Member member);
+
+    Optional<CombinationLike> findByCombinationAndMember(Combination combination, Member member);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/repository/CombinationLikeRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/repository/CombinationLikeRepository.java
@@ -3,7 +3,6 @@ package com.example.dgbackend.domain.combinationlike.repository;
 import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.combinationlike.CombinationLike;
 import com.example.dgbackend.domain.member.Member;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CombinationLikeRepository extends JpaRepository<CombinationLike, Long> {
@@ -11,6 +10,4 @@ public interface CombinationLikeRepository extends JpaRepository<CombinationLike
     void deleteByCombinationId(Long combinationId);
 
     boolean existsByCombinationAndMember(Combination combination, Member member);
-
-    Optional<CombinationLike> findByCombinationAndMember(Combination combination, Member member);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryService.java
@@ -1,9 +1,19 @@
 package com.example.dgbackend.domain.combinationlike.service;
 
 import com.example.dgbackend.domain.combination.Combination;
+import com.example.dgbackend.domain.combinationlike.CombinationLike;
 import com.example.dgbackend.domain.member.Member;
+import java.util.Optional;
 
 public interface CombinationLikeQueryService {
 
     boolean isCombinationLike(Combination combination, Member member);
+
+    Boolean changeCombinationLike(Long memberId, Long combinationId);
+
+    Optional<CombinationLike> getCombinationLikeEntity(Member member, Long combinationId);
+
+    Combination getCombinationEntity(Long combinationId);
+
+    CombinationLike createCombinationLike(Long combinationId, Member member);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryService.java
@@ -6,6 +6,4 @@ import com.example.dgbackend.domain.member.Member;
 public interface CombinationLikeQueryService {
 
     boolean isCombinationLike(Combination combination, Member member);
-
-    Boolean changeCombinationLike(Member member, Long combinationId);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryService.java
@@ -9,11 +9,7 @@ public interface CombinationLikeQueryService {
 
     boolean isCombinationLike(Combination combination, Member member);
 
-    Boolean changeCombinationLike(Long memberId, Long combinationId);
+    Boolean changeCombinationLike(Member member, Long combinationId);
 
     Optional<CombinationLike> getCombinationLikeEntity(Member member, Long combinationId);
-
-    Combination getCombinationEntity(Long combinationId);
-
-    CombinationLike createCombinationLike(Long combinationId, Member member);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryService.java
@@ -1,15 +1,11 @@
 package com.example.dgbackend.domain.combinationlike.service;
 
 import com.example.dgbackend.domain.combination.Combination;
-import com.example.dgbackend.domain.combinationlike.CombinationLike;
 import com.example.dgbackend.domain.member.Member;
-import java.util.Optional;
 
 public interface CombinationLikeQueryService {
 
     boolean isCombinationLike(Combination combination, Member member);
 
     Boolean changeCombinationLike(Member member, Long combinationId);
-
-    Optional<CombinationLike> getCombinationLikeEntity(Member member, Long combinationId);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryService.java
@@ -9,7 +9,11 @@ public interface CombinationLikeQueryService {
 
     boolean isCombinationLike(Combination combination, Member member);
 
-    Boolean changeCombinationLike(Member member, Long combinationId);
+    Boolean changeCombinationLike(Long memberId, Long combinationId);
 
     Optional<CombinationLike> getCombinationLikeEntity(Member member, Long combinationId);
+
+    Combination getCombinationEntity(Long combinationId);
+
+    CombinationLike createCombinationLike(Long combinationId, Member member);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryService.java
@@ -6,4 +6,6 @@ import com.example.dgbackend.domain.member.Member;
 public interface CombinationLikeQueryService {
 
     boolean isCombinationLike(Combination combination, Member member);
+
+    Boolean changeCombinationLike(Member member, Long combinationId);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryService.java
@@ -1,11 +1,15 @@
 package com.example.dgbackend.domain.combinationlike.service;
 
 import com.example.dgbackend.domain.combination.Combination;
+import com.example.dgbackend.domain.combinationlike.CombinationLike;
 import com.example.dgbackend.domain.member.Member;
+import java.util.Optional;
 
 public interface CombinationLikeQueryService {
 
     boolean isCombinationLike(Combination combination, Member member);
 
     Boolean changeCombinationLike(Member member, Long combinationId);
+
+    Optional<CombinationLike> getCombinationLikeEntity(Member member, Long combinationId);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
@@ -1,14 +1,9 @@
 package com.example.dgbackend.domain.combinationlike.service;
 
 import com.example.dgbackend.domain.combination.Combination;
-import com.example.dgbackend.domain.combination.repository.CombinationRepository;
 import com.example.dgbackend.domain.combinationlike.CombinationLike;
 import com.example.dgbackend.domain.combinationlike.repository.CombinationLikeRepository;
 import com.example.dgbackend.domain.member.Member;
-import com.example.dgbackend.domain.member.service.MemberService;
-import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
-import com.example.dgbackend.global.exception.ApiException;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,10 +15,6 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
 
     private final CombinationLikeRepository combinationLikeRepository;
 
-    private final CombinationRepository combinationRepository;
-
-    private final MemberService memberService;
-
     @Override
     public boolean isCombinationLike(Combination combination, Member member) {
 
@@ -34,20 +25,6 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
     @Transactional
     public Boolean changeCombinationLike(Member member, Long combinationId) {
 
-        Optional<CombinationLike> combinationLike = getCombinationLikeEntity(member, combinationId);
-
         return true;
-    }
-
-    //조합 id와 멤버 이름으로 조합 좋아요 엔티티를 조회
-    @Override
-    public Optional<CombinationLike> getCombinationLikeEntity(Member member, Long combinationId) {
-        Combination combination = combinationRepository.findById(combinationId)
-            .orElseThrow(() -> new ApiException(
-                ErrorStatus._COMBINATION_NOT_FOUND));
-
-        Member memberByName = memberService.findMemberByName(member.getName());
-
-        return combinationLikeRepository.findByCombinationAndMember(combination, memberByName);
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
@@ -5,7 +5,6 @@ import com.example.dgbackend.domain.combination.repository.CombinationRepository
 import com.example.dgbackend.domain.combinationlike.CombinationLike;
 import com.example.dgbackend.domain.combinationlike.repository.CombinationLikeRepository;
 import com.example.dgbackend.domain.member.Member;
-import com.example.dgbackend.domain.member.repository.MemberRepository;
 import com.example.dgbackend.domain.member.service.MemberService;
 import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
 import com.example.dgbackend.global.exception.ApiException;
@@ -25,8 +24,6 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
 
     private final MemberService memberService;
 
-    private final MemberRepository memberRepository;
-
     @Override
     public boolean isCombinationLike(Combination combination, Member member) {
 
@@ -35,10 +32,8 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
 
     @Override
     @Transactional
-    public Boolean changeCombinationLike(Long memberId, Long combinationId) {
+    public Boolean changeCombinationLike(Member member, Long combinationId) {
 
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_MEMBER));
         Optional<CombinationLike> combinationLike = getCombinationLikeEntity(member, combinationId);
 
         CombinationLike savedCombinationLike = combinationLike.map(CombinationLike::changeState)
@@ -47,13 +42,11 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
         return savedCombinationLike.nowCombinationLikeState();
     }
 
-    @Override
     public Combination getCombinationEntity(Long combinationId) {
         return combinationRepository.findById(combinationId)
             .orElseThrow(() -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND));
     }
 
-    @Override
     public CombinationLike createCombinationLike(Long combinationId, Member member) {
         return combinationLikeRepository.save(
             new CombinationLike(getCombinationEntity(combinationId), member));

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
@@ -36,29 +36,18 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
 
         Optional<CombinationLike> combinationLike = getCombinationLikeEntity(member, combinationId);
 
-        CombinationLike savedCombinationLike = combinationLike.map(CombinationLike::changeState)
-            .orElseGet(() -> createCombinationLike(combinationId, member));
-
-        return savedCombinationLike.nowCombinationLikeState();
-    }
-
-    public Combination getCombinationEntity(Long combinationId) {
-        return combinationRepository.findById(combinationId)
-            .orElseThrow(() -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND));
-    }
-
-    public CombinationLike createCombinationLike(Long combinationId, Member member) {
-        return combinationLikeRepository.save(
-            new CombinationLike(getCombinationEntity(combinationId), member));
+        return true;
     }
 
     //조합 id와 멤버 이름으로 조합 좋아요 엔티티를 조회
     @Override
     public Optional<CombinationLike> getCombinationLikeEntity(Member member, Long combinationId) {
+        Combination combination = combinationRepository.findById(combinationId)
+            .orElseThrow(() -> new ApiException(
+                ErrorStatus._COMBINATION_NOT_FOUND));
 
         Member memberByName = memberService.findMemberByName(member.getName());
 
-        return combinationLikeRepository.findByCombinationAndMember(
-            getCombinationEntity(combinationId), memberByName);
+        return combinationLikeRepository.findByCombinationAndMember(combination, memberByName);
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
@@ -1,8 +1,15 @@
 package com.example.dgbackend.domain.combinationlike.service;
 
 import com.example.dgbackend.domain.combination.Combination;
+import com.example.dgbackend.domain.combination.repository.CombinationRepository;
+import com.example.dgbackend.domain.combinationlike.CombinationLike;
 import com.example.dgbackend.domain.combinationlike.repository.CombinationLikeRepository;
 import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.member.repository.MemberRepository;
+import com.example.dgbackend.domain.member.service.MemberService;
+import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
+import com.example.dgbackend.global.exception.ApiException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,9 +21,51 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
 
     private final CombinationLikeRepository combinationLikeRepository;
 
+    private final CombinationRepository combinationRepository;
+
+    private final MemberService memberService;
+
+    private final MemberRepository memberRepository;
+
     @Override
     public boolean isCombinationLike(Combination combination, Member member) {
 
         return combinationLikeRepository.existsByCombinationAndMember(combination, member);
+    }
+
+    @Override
+    @Transactional
+    public Boolean changeCombinationLike(Long memberId, Long combinationId) {
+
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_MEMBER));
+        Optional<CombinationLike> combinationLike = getCombinationLikeEntity(member, combinationId);
+
+        CombinationLike savedCombinationLike = combinationLike.map(CombinationLike::changeState)
+            .orElseGet(() -> createCombinationLike(combinationId, member));
+
+        return savedCombinationLike.nowCombinationLikeState();
+    }
+
+    @Override
+    public Combination getCombinationEntity(Long combinationId) {
+        return combinationRepository.findById(combinationId)
+            .orElseThrow(() -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND));
+    }
+
+    @Override
+    public CombinationLike createCombinationLike(Long combinationId, Member member) {
+        return combinationLikeRepository.save(
+            new CombinationLike(getCombinationEntity(combinationId), member));
+    }
+
+    //조합 id와 멤버 이름으로 조합 좋아요 엔티티를 조회
+    @Override
+    public Optional<CombinationLike> getCombinationLikeEntity(Member member, Long combinationId) {
+
+        Member memberByName = memberService.findMemberByName(member.getName());
+
+        return combinationLikeRepository.findByCombinationAndMember(
+            getCombinationEntity(combinationId), memberByName);
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
@@ -36,18 +36,29 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
 
         Optional<CombinationLike> combinationLike = getCombinationLikeEntity(member, combinationId);
 
-        return true;
+        CombinationLike savedCombinationLike = combinationLike.map(CombinationLike::changeState)
+            .orElseGet(() -> createCombinationLike(combinationId, member));
+
+        return savedCombinationLike.nowCombinationLikeState();
+    }
+
+    public Combination getCombinationEntity(Long combinationId) {
+        return combinationRepository.findById(combinationId)
+            .orElseThrow(() -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND));
+    }
+
+    public CombinationLike createCombinationLike(Long combinationId, Member member) {
+        return combinationLikeRepository.save(
+            new CombinationLike(getCombinationEntity(combinationId), member));
     }
 
     //조합 id와 멤버 이름으로 조합 좋아요 엔티티를 조회
     @Override
     public Optional<CombinationLike> getCombinationLikeEntity(Member member, Long combinationId) {
-        Combination combination = combinationRepository.findById(combinationId)
-            .orElseThrow(() -> new ApiException(
-                ErrorStatus._COMBINATION_NOT_FOUND));
 
         Member memberByName = memberService.findMemberByName(member.getName());
 
-        return combinationLikeRepository.findByCombinationAndMember(combination, memberByName);
+        return combinationLikeRepository.findByCombinationAndMember(
+            getCombinationEntity(combinationId), memberByName);
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
@@ -1,7 +1,6 @@
 package com.example.dgbackend.domain.combinationlike.service;
 
 import com.example.dgbackend.domain.combination.Combination;
-import com.example.dgbackend.domain.combinationlike.CombinationLike;
 import com.example.dgbackend.domain.combinationlike.repository.CombinationLikeRepository;
 import com.example.dgbackend.domain.member.Member;
 import lombok.RequiredArgsConstructor;
@@ -19,12 +18,5 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
     public boolean isCombinationLike(Combination combination, Member member) {
 
         return combinationLikeRepository.existsByCombinationAndMember(combination, member);
-    }
-
-    @Override
-    @Transactional
-    public Boolean changeCombinationLike(Member member, Long combinationId) {
-
-        return true;
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
@@ -1,9 +1,14 @@
 package com.example.dgbackend.domain.combinationlike.service;
 
 import com.example.dgbackend.domain.combination.Combination;
+import com.example.dgbackend.domain.combination.repository.CombinationRepository;
 import com.example.dgbackend.domain.combinationlike.CombinationLike;
 import com.example.dgbackend.domain.combinationlike.repository.CombinationLikeRepository;
 import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.member.service.MemberService;
+import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
+import com.example.dgbackend.global.exception.ApiException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +20,10 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
 
     private final CombinationLikeRepository combinationLikeRepository;
 
+    private final CombinationRepository combinationRepository;
+
+    private final MemberService memberService;
+
     @Override
     public boolean isCombinationLike(Combination combination, Member member) {
 
@@ -25,6 +34,20 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
     @Transactional
     public Boolean changeCombinationLike(Member member, Long combinationId) {
 
+        Optional<CombinationLike> combinationLike = getCombinationLikeEntity(member, combinationId);
+
         return true;
+    }
+
+    //조합 id와 멤버 이름으로 조합 좋아요 엔티티를 조회
+    @Override
+    public Optional<CombinationLike> getCombinationLikeEntity(Member member, Long combinationId) {
+        Combination combination = combinationRepository.findById(combinationId)
+            .orElseThrow(() -> new ApiException(
+                ErrorStatus._COMBINATION_NOT_FOUND));
+
+        Member memberByName = memberService.findMemberByName(member.getName());
+
+        return combinationLikeRepository.findByCombinationAndMember(combination, memberByName);
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.dgbackend.domain.combinationlike.service;
 
 import com.example.dgbackend.domain.combination.Combination;
+import com.example.dgbackend.domain.combinationlike.CombinationLike;
 import com.example.dgbackend.domain.combinationlike.repository.CombinationLikeRepository;
 import com.example.dgbackend.domain.member.Member;
 import lombok.RequiredArgsConstructor;
@@ -18,5 +19,12 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
     public boolean isCombinationLike(Combination combination, Member member) {
 
         return combinationLikeRepository.existsByCombinationAndMember(combination, member);
+    }
+
+    @Override
+    @Transactional
+    public Boolean changeCombinationLike(Member member, Long combinationId) {
+
+        return true;
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
@@ -5,6 +5,7 @@ import com.example.dgbackend.domain.combination.repository.CombinationRepository
 import com.example.dgbackend.domain.combinationlike.CombinationLike;
 import com.example.dgbackend.domain.combinationlike.repository.CombinationLikeRepository;
 import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.member.repository.MemberRepository;
 import com.example.dgbackend.domain.member.service.MemberService;
 import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
 import com.example.dgbackend.global.exception.ApiException;
@@ -24,6 +25,8 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
 
     private final MemberService memberService;
 
+    private final MemberRepository memberRepository;
+
     @Override
     public boolean isCombinationLike(Combination combination, Member member) {
 
@@ -32,8 +35,10 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
 
     @Override
     @Transactional
-    public Boolean changeCombinationLike(Member member, Long combinationId) {
+    public Boolean changeCombinationLike(Long memberId, Long combinationId) {
 
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_MEMBER));
         Optional<CombinationLike> combinationLike = getCombinationLikeEntity(member, combinationId);
 
         CombinationLike savedCombinationLike = combinationLike.map(CombinationLike::changeState)
@@ -42,11 +47,13 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
         return savedCombinationLike.nowCombinationLikeState();
     }
 
+    @Override
     public Combination getCombinationEntity(Long combinationId) {
         return combinationRepository.findById(combinationId)
             .orElseThrow(() -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND));
     }
 
+    @Override
     public CombinationLike createCombinationLike(Long combinationId, Member member) {
         return combinationLikeRepository.save(
             new CombinationLike(getCombinationEntity(combinationId), member));


### PR DESCRIPTION
## 요약

- 오늘의 조합 좋아요 누르기 API를 구현합니다.

## 상세 내용

- 메이슨과 제가 구현했던 방식을 섞어서 구현해보았는데, 메이슨과 달리 좋아요 여부 API는 구현하지 않았습니다. 프론트와 상의하에 필요하다고 하면 추후 구현하도록 하겠습니다.
- 기본 유저는 Long memberId를 통해 구현했는데, 이 또한 로그인이 완료되면 추후 수정하도록 하겠습니다.

- 한번 누를 시 
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/125117389/fd41134b-2f0a-4c3c-8d39-ab636b432847)

![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/125117389/e69c3b5a-5220-40fa-ac73-6073423278b4)

- 다시 한번 누를 시
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/125117389/fda169c4-78dd-490d-bc27-7e04e6347846)

![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/125117389/5c70f5cf-7a91-4edd-8f09-42bc833e5ca6)


## 질문 및 이외 사항

- 이슈 번호를 착각해 카일로의 #75 번 PR에 커밋이 따라갔습니다,,, revert 후 push 하였는데, 이게 올바른 방법인진 모르겠습니다 ㅠㅠ 다행히 해당 PR에 제가 수정한 커밋은 반영되지 않은 것 같습니다.. 앞으로는 주의하도록 하겠습니다!

## 이슈 번호

- close #76 