### PR TITLE
Feat: 타이틀로 검색 API

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
@@ -120,4 +120,13 @@ public class CombinationController {
         return ApiResponse.onSuccess(
             combinationQueryService.getWeeklyBestCombinationPreviewResultList(page));
     }
+
+    @Operation(summary = "오늘의 조합 검색", description = "오늘의 조합 목록을 검색합니다.")
+    @GetMapping("/search")
+    public ApiResponse<CombinationResponse.CombinationPreviewResultList> findCombinationsListByKeyWord(
+        @RequestParam(name = "page") Integer page, @RequestParam(name = "keyword") String keyword) {
+        return ApiResponse.onSuccess(
+            combinationQueryService.findCombinationsListByKeyword(page, keyword));
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
@@ -129,4 +129,12 @@ public class CombinationController {
             combinationQueryService.findCombinationsListByKeyword(page, keyword));
     }
 
+    @Operation(summary = "주간 베스트 조합 검색", description = "주간 베스트 조합 목록을 검색합니다.")
+    @GetMapping("/weekly-best/search")
+    public ApiResponse<CombinationResponse.CombinationPreviewResultList> findWeeklyBestCombinationsListByKeyWord(
+        @RequestParam(name = "page") Integer page, @RequestParam(name = "keyword") String keyword) {
+        return ApiResponse.onSuccess(
+            combinationQueryService.findWeeklyBestCombinationsListByKeyWord(page, keyword));
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
@@ -9,4 +9,7 @@ public interface CombinationRepository extends JpaRepository<Combination, Long> 
 
     Page<Combination> findCombinationsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
         Long likeCount, PageRequest pageRequest);
+
+    Page<Combination> findCombinationsByTitleContaining(String keyword, PageRequest pageRequest);
+
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
@@ -12,4 +12,8 @@ public interface CombinationRepository extends JpaRepository<Combination, Long> 
 
     Page<Combination> findCombinationsByTitleContaining(String keyword, PageRequest pageRequest);
 
+    Page<Combination> findCombinationsByTitleContainingAndLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
+        String keyword, PageRequest pageRequest, Long likeCount);
+
+
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
@@ -22,4 +22,7 @@ public interface CombinationQueryService {
 
     CombinationPreviewResultList findCombinationsListByKeyword(Integer page, String keyword);
 
+    CombinationPreviewResultList findWeeklyBestCombinationsListByKeyWord(Integer page,
+        String keyword);
+
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
@@ -20,4 +20,6 @@ public interface CombinationQueryService {
 
     CombinationPreviewResultList getWeeklyBestCombinationPreviewResultList(Integer page);
 
+    CombinationPreviewResultList findCombinationsListByKeyword(Integer page, String keyword);
+
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -67,17 +67,18 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
             () -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND)
         );
 
-
         // TODO : Login Member 추후에 Token을 통해 정보 얻기
         Member loginMember = memberRepository.findById(1L).get();
 
         // CombinationLike
-        boolean isCombinationLike = combinationLikeQueryService.isCombinationLike(combination, loginMember);
+        boolean isCombinationLike = combinationLikeQueryService.isCombinationLike(combination,
+            loginMember);
 
         // HashTagOption
-        List<HashTagOption> hashTagOptions = hashTagOptionRepository.findAllByCombinationWithFetch(combination);
-        CombinationResult combinationResult = toCombinationResult(combination, hashTagOptions, isCombinationLike);
-
+        List<HashTagOption> hashTagOptions = hashTagOptionRepository.findAllByCombinationWithFetch(
+            combination);
+        CombinationResult combinationResult = toCombinationResult(combination, hashTagOptions,
+            isCombinationLike);
 
         // Member - 작성자
         Member member = combination.getMember();
@@ -129,6 +130,22 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
         PageRequest pageRequest = PageRequest.of(page, 10);
         Page<Combination> combinations = combinationRepository.findCombinationsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
             30L, pageRequest);
+
+        List<Combination> combinationList = combinations.getContent();
+        List<List<HashTagOption>> hashTagOptionList = combinationList.stream()
+            .map(hashTagOptionRepository::findAllByCombinationWithFetch)
+            .toList();
+
+        return toCombinationPreviewResultList(combinations, hashTagOptionList);
+    }
+
+    @Override
+    public CombinationPreviewResultList findCombinationsListByKeyword(Integer page,
+        String keyword) {
+        PageRequest pageRequest = PageRequest.of(page, 10);
+
+        Page<Combination> combinations = combinationRepository.findCombinationsByTitleContaining(
+            keyword, pageRequest);
 
         List<Combination> combinationList = combinations.getContent();
         List<List<HashTagOption>> hashTagOptionList = combinationList.stream()

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -155,4 +155,20 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
         return toCombinationPreviewResultList(combinations, hashTagOptionList);
     }
 
+    @Override
+    public CombinationPreviewResultList findWeeklyBestCombinationsListByKeyWord(Integer page,
+        String keyword) {
+        PageRequest pageRequest = PageRequest.of(page, 10);
+
+        Page<Combination> combinations = combinationRepository.findCombinationsByTitleContainingAndLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
+            keyword, pageRequest, 30L);
+
+        List<Combination> combinationList = combinations.getContent();
+        List<List<HashTagOption>> hashTagOptionList = combinationList.stream()
+            .map(hashTagOptionRepository::findAllByCombinationWithFetch)
+            .toList();
+
+        return toCombinationPreviewResultList(combinations, hashTagOptionList);
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/controller/RecipeController.java
@@ -12,10 +12,17 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "레시피북 API")
 @RestController
@@ -29,9 +36,10 @@ public class RecipeController {
     //TODO: @AutenticationPrincipal로 변경
     private final MemberRepository memberRepository;
     private Member member = Member.builder()
-            .name("김동규").email("email@email.com").birthDate("birthDate")
-            .phoneNumber("phoneNumber").nickName("nickName").gender(Gender.MALE).socialType(SocialType.APPLE)
-            .build();
+        .name("김동규").email("email@email.com").birthDate("birthDate")
+        .phoneNumber("phoneNumber").nickName("nickName").gender(Gender.MALE)
+        .socialType(SocialType.APPLE)
+        .build();
 
     @Operation(summary = "모든 레시피북 조회", description = "삭제되지 않은 레시피북 목록을 조회합니다.")
     @GetMapping
@@ -55,7 +63,8 @@ public class RecipeController {
     @Operation(summary = "레시피북 수정", description = "레시피북을 수정합니다.")
     @Parameter(name = "recipeId", description = "레시피북 Id, Path Variable 입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @PatchMapping("/{recipeId}")
-    public ApiResponse<RecipeResponse> updateRecipe(@PathVariable Long recipeId, @RequestBody RecipeRequest recipeRequest) {
+    public ApiResponse<RecipeResponse> updateRecipe(@PathVariable Long recipeId,
+        @RequestBody RecipeRequest recipeRequest) {
         return ApiResponse.onSuccess(recipeServiceImpl.updateRecipe(recipeId, recipeRequest));
     }
 
@@ -65,6 +74,13 @@ public class RecipeController {
     public ApiResponse<String> deleteRecipe(@PathVariable Long recipeId) {
         recipeServiceImpl.deleteRecipe(recipeId);
         return ApiResponse.onSuccess("삭제 완료");
+    }
+
+    @Operation(summary = "레시피북 검색", description = "레시피북 목록을 검색합니다.")
+    @GetMapping("/search")
+    public ApiResponse<List<RecipeResponse>> findCombinationsListByKeyWord(
+        @RequestParam(name = "page") Integer page, @RequestParam(name = "keyword") String keyword) {
+        return ApiResponse.onSuccess(recipeServiceImpl.findRecipesByKeyword(page, keyword));
     }
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/repository/RecipeRepository.java
@@ -1,12 +1,14 @@
 package com.example.dgbackend.domain.recipe.repository;
 
 import com.example.dgbackend.domain.recipe.Recipe;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-import java.util.Optional;
-
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
+
     List<Recipe> findAllByState(boolean state);
+
     List<Recipe> findAllByNameAndMember_Name(String name, String memberName);
+
+    List<Recipe> findRecipesByNameContaining(String keyword);
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeService.java
@@ -4,7 +4,6 @@ import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.recipe.Recipe;
 import com.example.dgbackend.domain.recipe.dto.RecipeRequest;
 import com.example.dgbackend.domain.recipe.dto.RecipeResponse;
-
 import java.util.List;
 
 public interface RecipeService {
@@ -26,5 +25,7 @@ public interface RecipeService {
     Recipe isDelete(Recipe recipe);
 
     void isAlreadyCreate(String RecipeName, String memberName);
+
+    List<RecipeResponse> findRecipesByKeyword(Integer page, String keyword);
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
@@ -9,11 +9,10 @@ import com.example.dgbackend.domain.recipe.repository.RecipeRepository;
 import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
 import com.example.dgbackend.global.exception.ApiException;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -26,8 +25,8 @@ public class RecipeServiceImpl implements RecipeService {
     @Override
     public List<RecipeResponse> getExistRecipes() {
         return recipeRepository.findAllByState(true).stream()
-                .map(RecipeResponse::toResponse)
-                .toList();
+            .map(RecipeResponse::toResponse)
+            .toList();
     }
 
     @Override
@@ -41,7 +40,8 @@ public class RecipeServiceImpl implements RecipeService {
 
         Member memberEntity = memberService.findMemberByName(member.getName());
         isAlreadyCreate(recipeRequest.getName(), memberEntity.getName());
-        return RecipeResponse.toResponse(recipeRepository.save(RecipeRequest.toEntity(recipeRequest, memberEntity)));
+        return RecipeResponse.toResponse(
+            recipeRepository.save(RecipeRequest.toEntity(recipeRequest, memberEntity)));
     }
 
     @Override
@@ -63,7 +63,7 @@ public class RecipeServiceImpl implements RecipeService {
     public Recipe getRecipe(Long id) {
 
         Recipe recipe = recipeRepository.findById(id)
-                .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE));
+            .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE));
 
         return isDelete(recipe);
     }
@@ -72,7 +72,9 @@ public class RecipeServiceImpl implements RecipeService {
     @Override
     public Recipe isDelete(Recipe recipe) {
 
-        if (!recipe.isState()) throw new ApiException(ErrorStatus._DELETE_RECIPE);
+        if (!recipe.isState()) {
+            throw new ApiException(ErrorStatus._DELETE_RECIPE);
+        }
 
         return recipe;
     }
@@ -80,11 +82,18 @@ public class RecipeServiceImpl implements RecipeService {
     @Override
     public void isAlreadyCreate(String RecipeName, String memberName) {
         recipeRepository.findAllByNameAndMember_Name(RecipeName, memberName).stream()
-                .filter(Recipe::isState)
-                .findFirst()
-                .ifPresent(recipe -> {
-                    throw new ApiException(ErrorStatus._ALREADY_CREATE_RECIPE);
-                });
+            .filter(Recipe::isState)
+            .findFirst()
+            .ifPresent(recipe -> {
+                throw new ApiException(ErrorStatus._ALREADY_CREATE_RECIPE);
+            });
+    }
+
+    @Override
+    public List<RecipeResponse> findRecipesByKeyword(Integer page, String keyword) {
+        return recipeRepository.findRecipesByNameContaining(keyword).stream()
+            .map(RecipeResponse::toResponse)
+            .toList();
     }
 
 }


### PR DESCRIPTION
## 요약

- 타이틀로 검색 기능을 구현합니다.

## 상세 내용

- 오늘의 조합 검색
- 주간 베스트 조합 검색
- 레시피 북 검색
- 총 세개로 분리하여 현재는 제목으로만 검색이 가능하도록 구현하였습니다.
- 전부 `findCombinationsByTitleContaining` 과 같은 JPA 메소드를 이용해 구현하였습니다.

## 질문 및 이외 사항

- 해시태그로 검색 기능은 추후 구현하도록 하겠습니다.
- 코딩 컨벤션을 적용하여 수정된 파일이 조금 많습니다! 양해 부탁드립니다.
- 레시피북에서는 paging이 적용되어 있지 않아 일단 메이슨이 구현한 방식으로 하였고, 추후 수정이 필요할 듯 합니다.

## 이슈 번호

- close #88 