### PR TITLE
Feat : 레시피 Count 변경 기능 추가

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/recipe/Recipe.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/Recipe.java
@@ -67,4 +67,23 @@ public class Recipe extends BaseTimeEntity {
         return this;
     }
 
+    public void changeLikeCount(boolean isIncrease) {
+
+        if (isIncrease) {
+            this.likeCount++;
+        } else {
+            this.likeCount--;
+        }
+
+    }
+
+    public void changeCommentCount(boolean isIncrease) {
+
+        if (isIncrease) {
+            this.commentCount++;
+        } else {
+            this.commentCount--;
+        }
+
+    }
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/RecipeComment.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/RecipeComment.java
@@ -48,6 +48,7 @@ public class RecipeComment extends BaseTimeEntity {
     }
 
     public RecipeComment delete() {
+        this.recipe.changeCommentCount(false);
         this.state = false;
         return this;
     }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
@@ -41,7 +41,11 @@ public class RecipeCommentServiceImpl implements RecipeCommentService {
     @Override
     @Transactional
     public RecipeCommentResponse saveRecipeComment(RecipeCommentVO paramVO) {
-        return RecipeCommentResponse.toResponse(recipeCommentRepository.save(getEntity(paramVO)));
+        RecipeComment save = recipeCommentRepository.save(getEntity(paramVO));
+
+        //댓글 수 증가
+        save.getRecipe().changeCommentCount(true);
+        return RecipeCommentResponse.toResponse(save);
     }
 
     @Override

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
@@ -88,7 +88,13 @@ public class RecipeCommentServiceImpl implements RecipeCommentService {
     @Override
     @Transactional
     public RecipeCommentResponse deleteRecipeComment(Long recipeCommentId) {
-        RecipeComment recipeComment = getEntityById(recipeCommentId).delete();
+        RecipeComment entityById = getEntityById(recipeCommentId);
+
+        if (!entityById.isState()) {
+            throw new ApiException(ErrorStatus._Already_DELETE_RECIPE_COMMENT);
+        }
+
+        RecipeComment recipeComment = entityById.delete();
 
         //대댓글도 삭제
         recipeComment.getChildCommentList().forEach(RecipeComment::delete);

--- a/src/main/java/com/example/dgbackend/domain/recipelike/RecipeLike.java
+++ b/src/main/java/com/example/dgbackend/domain/recipelike/RecipeLike.java
@@ -28,7 +28,12 @@ public class RecipeLike extends BaseTimeEntity {
     private Recipe recipe;
 
     public RecipeLike changeState() {
-        this.state = !this.state;
+        boolean isDecrease = this.state;
+
+        // true -> false, false -> true
+        this.state = !isDecrease;
+        this.recipe.changeLikeCount(!isDecrease);
+
         return this;
     }
 

--- a/src/main/java/com/example/dgbackend/domain/recipelike/service/RecipeLikeServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipelike/service/RecipeLikeServiceImpl.java
@@ -48,10 +48,15 @@ public class RecipeLikeServiceImpl implements RecipeLikeService {
     }
 
     @Override
+    @Transactional
     public RecipeLike createRecipe(RecipeLikeVO recipeLikeVO) {
         Recipe recipe = recipeServiceImpl.getRecipe(recipeLikeVO.getRecipeId());
         Member member = memberService.findMemberByName(recipeLikeVO.getMemberName());
-        return recipeLikeRepository.save(RecipeLikeRequest.toEntity(recipe, member));
+
+        //레시피 좋아요 엔티티 생성 ㅎ  증가
+        RecipeLike save = recipeLikeRepository.save(RecipeLikeRequest.toEntity(recipe, member));
+        recipe.changeLikeCount(true);
+        return save;
     }
 
 

--- a/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
@@ -58,6 +58,7 @@ public enum ErrorStatus implements BaseErrorCode {
     //레시피 댓글
     _EMPTY_RECIPE_COMMENT(HttpStatus.CONFLICT, "RECIPE_COMMENT_001", "존재하지 않는 레시피 댓글입니다."),
     _OVER_DEPTH_RECIPE_COMMENT(HttpStatus.BAD_REQUEST, "RECIPE_COMMENT_003", "대댓글까지만 가능합니다."),
+    _Already_DELETE_RECIPE_COMMENT(HttpStatus.BAD_REQUEST, "RECIPE_COMMENT_004", "이미 삭제된 댓글입니다."),
 
     //레시피 이미지
     _EMPTY_RECIPE_IMAGE(HttpStatus.CONFLICT, "RECIPE_IMAGE_001", "존재하지 않는 레시피 이미지입니다."),


### PR DESCRIPTION
## 요약

- 레시피 Count 변경 기능 추가

## 상세 내용

- 레시피 댓글, 좋아요 변경 시 해당 레시피의 Count 변경될 수 있게 하였습니다
- 수정사항
    - 레시피 댓글 삭제시
    - 레시피 댓글 등록시
    - 레시피 댓글 처음 좋아요일 때
    - 레시피 좋아요 바뀔 때

### Postman 테스트

#### 🚩기본 레시피
<img width="340" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/0d52ff57-c0aa-474e-9924-84fbe717e57b">

#### 🚩댓글 2개 추가시
<img width="356" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/485b206e-88b3-487e-bcb4-ab7f8b3dfb17">

#### 🚩댓글 1개 삭제시
<img width="347" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/71fae55d-21fe-4380-bfa4-102967d5479d">

#### 🚩 첫 좋아요 일 때
<img width="374" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/b86a3204-403d-42a5-bf1d-8ba37bc2a0f1">

#### 🚩 좋아요 취소(변경 시)
<img width="365" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/7473d4c8-970e-49f5-9ae5-384444955f6b">



---

## 질문 및 이외 사항

## 이슈 번호

- Close  #95 