### PR TITLE
Fix: Recommend 도메인 Member어노테이션 추가 및 Soft Delete구현

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/recommend/Recommend.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/Recommend.java
@@ -5,12 +5,20 @@ import com.example.dgbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.Where;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @Entity
+@SQLDelete(sql = "UPDATE recommend SET deleted = true WHERE id = ?")
+@SQLRestriction("deleted = false")
+@OnDelete(action = OnDeleteAction.CASCADE)
 public class Recommend extends BaseTimeEntity {
 
     @Id
@@ -35,6 +43,8 @@ public class Recommend extends BaseTimeEntity {
 
     @NotNull
     private String imageUrl;
+
+    private Boolean deleted = Boolean.FALSE;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/example/dgbackend/domain/recommend/Recommend.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/Recommend.java
@@ -5,6 +5,7 @@ import com.example.dgbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.SQLDelete;
@@ -44,6 +45,7 @@ public class Recommend extends BaseTimeEntity {
     @NotNull
     private String imageUrl;
 
+    @Builder.Default()
     private Boolean deleted = Boolean.FALSE;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/dgbackend/domain/recommend/controller/RecommendController.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/controller/RecommendController.java
@@ -42,7 +42,7 @@ public class RecommendController {
     })
     @Parameter(name = "recommendId", description = "특정 recommend 정보 가져오기, Path Variable 입니다.")
     @PostMapping("/{recommendId}")
-    public ApiResponse<RecommendResponse.RecommendResult> getRecommend(@PathVariable(name = "recommendId") Long recommendId) {
+    public ApiResponse<RecommendResponse.RecommendResponseDTO> getRecommend(@PathVariable(name = "recommendId") Long recommendId) {
 
         return ApiResponse.onSuccess(recommendQueryService.getRecommendResult(recommendId));
     }
@@ -62,7 +62,7 @@ public class RecommendController {
     })
     @Parameter(name = "recommendId", description = "내가 받은 추천 조합 Id, Path Variable 입니다.")
     @DeleteMapping("/{recommendId}")
-    public ApiResponse<RecommendResponse.RecommendResult> deleteRecommend(@PathVariable(name = "recommendId") Long recommendId) {
+    public ApiResponse<RecommendResponse.RecommendResponseDTO> deleteRecommend(@PathVariable(name = "recommendId") Long recommendId) {
 
         return ApiResponse.onSuccess(recommendQueryService.deleteRecommend(recommendId));
     }

--- a/src/main/java/com/example/dgbackend/domain/recommend/controller/RecommendController.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/controller/RecommendController.java
@@ -24,7 +24,6 @@ import org.springframework.web.bind.annotation.*;
 public class RecommendController {
     private final RecommendCommandService recommendCommandService;
     private final RecommendQueryService recommendQueryService;
-    private final MemberRepository memberRepository;
 
     @Operation(summary = "주류 추천 요청", description = "GPT API에 추류 추천 요청을 보내고 응답을 받아옵니다.")
     @ApiResponses(value = {
@@ -41,7 +40,7 @@ public class RecommendController {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "추천 받은 조합 조회 성공")
     })
-    @Parameter(name = "recommendId", description = "내가 받은 추천 조합 Id, Path Variable 입니다.")
+    @Parameter(name = "recommendId", description = "특정 recommend 정보 가져오기, Path Variable 입니다.")
     @PostMapping("/{recommendId}")
     public ApiResponse<RecommendResponse.RecommendResult> getRecommend(@PathVariable(name = "recommendId") Long recommendId) {
 
@@ -52,9 +51,9 @@ public class RecommendController {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "추천 받은 조합 리스트 조회 성공")
     })
-    @GetMapping("/list/{MemberID}")
-    public ApiResponse<RecommendResponse.RecommendListResult> getRecommendList(@PathVariable(name = "MemberID") Long memberID, @RequestParam(name = "page") Integer page, @RequestParam(name = "size") Integer size) {
-        return ApiResponse.onSuccess(recommendQueryService.getRecommendListResult(memberID, page, size));
+    @GetMapping("/list")
+    public ApiResponse<RecommendResponse.RecommendListResult> getRecommendList(@MemberObject Member member, @RequestParam(name = "page") Integer page, @RequestParam(name = "size") Integer size) {
+        return ApiResponse.onSuccess(recommendQueryService.getRecommendListResult(member, page, size));
     }
   
     @Operation(summary = "오늘의 조합 - 추천 받은 조합 삭제", description = "추천 받은 조합을 선택하여 오늘의 조합을 작성합니다.")

--- a/src/main/java/com/example/dgbackend/domain/recommend/dto/RecommendResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/dto/RecommendResponse.java
@@ -32,19 +32,10 @@ public class RecommendResponse {
         private RecommendRequest.GPTMessage message;
     }
 
-    //TODO :RecommendResponseDTO와 통합할 예정
-    @Builder
-    @Getter
-    public static class RecommendResult {
-        String drinkName;
-        String drinkInfo;
-        String imageUrl;
-    }
-
     @Getter
     @Builder
     public static class RecommendListResult {
-        List<RecommendResult> recommendResponseDTOList;
+        List<RecommendResponseDTO> recommendResponseDTOList;
         Integer listSize;
         Integer totalPage;
         Long totalElements;
@@ -52,10 +43,11 @@ public class RecommendResponse {
         Boolean isLast;
     }
 
-    public static RecommendResult toRecommendResult(Recommend recommend) {
-        return RecommendResult.builder()
+    public static RecommendResponseDTO toRecommendResult(Recommend recommend) {
+        return RecommendResponseDTO.builder()
+                .foodName(recommend.getFoodName())
                 .drinkName(recommend.getDrinkName())
-                .drinkInfo(recommend.getDrinkInfo())
+                .recommendReason(recommend.getDrinkInfo())
                 .imageUrl(recommend.getImageUrl())
                 .build();
     }

--- a/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendCommandService.java
@@ -6,6 +6,6 @@ import com.example.dgbackend.domain.recommend.dto.RecommendResponse;
 
 public interface RecommendCommandService {
     RecommendResponse.RecommendResponseDTO requestRecommend(Member member, RecommendRequest.RecommendRequestDTO recommendRequestDTO);
-    String makeCombinationImage(Long memberID, String drinkName, RecommendRequest.RecommendRequestDTO requestDTO);
+    String makeCombinationImage(Member member, String drinkName, RecommendRequest.RecommendRequestDTO requestDTO);
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendCommandServiceImpl.java
@@ -96,7 +96,7 @@ public class RecommendCommandServiceImpl implements RecommendCommandService {
         String reason = gptResult.get("Reason");
 
         //추천 결과 이미지 생성
-        String imageUrl = makeCombinationImage(member.getId(), drinkType, recommendRequestDTO);
+        String imageUrl = makeCombinationImage(member, drinkType, recommendRequestDTO);
         //추천 결과 DB에 저장
         recommendQueryService.addRecommend(member, recommendRequestDTO, drinkType, reason, imageUrl);
 
@@ -171,11 +171,7 @@ public class RecommendCommandServiceImpl implements RecommendCommandService {
     drinkType : 추천된 주종
     requestDTO : 추천 요청 정보
      */
-    public String makeCombinationImage(Long memberID, String drinkName, RecommendRequest.RecommendRequestDTO requestDTO) {
-
-        // 사용자 선호 정보 추출을 위한 Member 객체 생성
-        Member member = memberRepository.findById(memberID).orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_MEMBER));
-
+    public String makeCombinationImage(Member member, String drinkName, RecommendRequest.RecommendRequestDTO requestDTO) {
         //Dall e API 요청 헤더 설정
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);

--- a/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendQueryService.java
@@ -12,7 +12,7 @@ public interface RecommendQueryService {
 
     RecommendResult getRecommendResult(Long recommendId);
 
-    RecommendResponse.RecommendListResult getRecommendListResult(Long memberID, Integer page, Integer size);
+    RecommendResponse.RecommendListResult getRecommendListResult(Member member, Integer page, Integer size);
 
     RecommendResult deleteRecommend(Long recommendId);          //추천 삭제
 }

--- a/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendQueryService.java
@@ -3,16 +3,15 @@ package com.example.dgbackend.domain.recommend.service;
 import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.recommend.dto.RecommendRequest;
 import com.example.dgbackend.domain.recommend.dto.RecommendResponse;
-
-import static com.example.dgbackend.domain.recommend.dto.RecommendResponse.RecommendResult;
+import com.example.dgbackend.domain.recommend.dto.RecommendResponse.RecommendResponseDTO;
 
 public interface RecommendQueryService {
 
     void addRecommend(Member member, RecommendRequest.RecommendRequestDTO recommendRequestDTO, String drinkName, String drinkInfo, String imageUrl);
 
-    RecommendResult getRecommendResult(Long recommendId);
+    RecommendResponseDTO getRecommendResult(Long recommendId);
 
     RecommendResponse.RecommendListResult getRecommendListResult(Member member, Integer page, Integer size);
 
-    RecommendResult deleteRecommend(Long recommendId);          //추천 삭제
+    RecommendResponseDTO deleteRecommend(Long recommendId);          //추천 삭제
 }

--- a/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendQueryServiceImpl.java
@@ -36,12 +36,13 @@ public class RecommendQueryServiceImpl implements RecommendQueryService {
                 .drinkInfo(drinkInfo)
                 .imageUrl(imageUrl)
                 .member(member)
+//                .deleted(false)
                 .build();
         recommendRepository.save(recommend);
     }
         
     @Override
-    public RecommendResponse.RecommendResult getRecommendResult(Long recommendId) {
+    public RecommendResponse.RecommendResponseDTO getRecommendResult(Long recommendId) {
 
         Recommend recommend = recommendRepository.findById(recommendId).orElseThrow(
                 () -> new ApiException(ErrorStatus._RECOMMEND_NOT_FOUND)
@@ -67,7 +68,7 @@ public class RecommendQueryServiceImpl implements RecommendQueryService {
     }
 
     @Override
-    public RecommendResponse.RecommendResult deleteRecommend(Long recommendId) {
+    public RecommendResponse.RecommendResponseDTO deleteRecommend(Long recommendId) {
         Recommend recommend = recommendRepository.findById(recommendId).orElseThrow(
                 () -> new ApiException(ErrorStatus._RECOMMEND_NOT_FOUND)
         );

--- a/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendQueryServiceImpl.java
@@ -52,11 +52,7 @@ public class RecommendQueryServiceImpl implements RecommendQueryService {
     }
 
     @Override
-    public RecommendResponse.RecommendListResult getRecommendListResult(Long memberID, Integer page, Integer size) {
-        Member member = memberRepository.findById(memberID).orElseThrow(
-                () -> new ApiException(ErrorStatus._EMPTY_MEMBER)
-        );
-
+    public RecommendResponse.RecommendListResult getRecommendListResult(Member member, Integer page, Integer size) {
         Pageable pageable = Pageable.ofSize(size).withPage(page);
         Page<Recommend> pageList = recommendRepository.findAllByMemberId(member.getId(), pageable);
 

--- a/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
@@ -25,9 +25,6 @@ public enum ErrorStatus implements BaseErrorCode {
     _COMBINATION_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMBINATION_COMMENT_001", "존재하지 않는 오늘의 조합 댓글입니다."),
     _OVER_DEPTH_COMBINATION_COMMENT(HttpStatus.BAD_REQUEST, "COMBINATION_COMMENT_002", "대댓글까지만 가능합니다."),
 
-    //Recommend 관련
-    _RECOMMEND_NOT_FOUND(HttpStatus.NOT_FOUND, "RECOMMEND_001", "존재하지 않는 추천 조합입니다."),
-
     //CombinationImage 관련
     _COMBINATION_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "COMBINATION_IMAGE_001", "존재하지 않는 이미지입니다."),
 
@@ -46,9 +43,10 @@ public enum ErrorStatus implements BaseErrorCode {
     //Redis 관련
     _REDIS_NOT_FOUND(HttpStatus.NOT_FOUND, "REDIS_001", "Redis에 존재하지 않는 Key 입니다."),
 
-    //주류 추천 관련
-    _NULL_DESIRE_LEVEL(HttpStatus.BAD_REQUEST, "RECOMMEND_001", "취하고 싶은 정도를 입력해주세요."),
-    _NULL_FOOD_NAME(HttpStatus.BAD_REQUEST, "RECOMMEND_002", "음식 이름을 입력해주세요."),
+    //Recommend 관련
+    _RECOMMEND_NOT_FOUND(HttpStatus.NOT_FOUND, "RECOMMEND_001", "존재하지 않는 추천 조합입니다."),
+    _NULL_DESIRE_LEVEL(HttpStatus.BAD_REQUEST, "RECOMMEND_002", "취하고 싶은 정도를 입력해주세요."),
+    _NULL_FOOD_NAME(HttpStatus.BAD_REQUEST, "RECOMMEND_003", "음식 이름을 입력해주세요."),
   
     //레시피
     _EMPTY_RECIPE(HttpStatus.CONFLICT, "RECIPE_001", "존재하지 않는 레시피입니다."),


### PR DESCRIPTION
## 요약
- RecommendController에 MemberObject어노테이션 적용
- Hard Delete -> Soft Delete 변경
- ResponseDTO 동일 기능 객체 통합
- Recoomend 관련 ErrorStatus 수정 (code가 중복되어있었음)

## 상세 내용

내가 추천 받은 조합 리스트 조회 API 변경 (path variable -> MemberObject annotation)
<img width="1044" alt="스크린샷 2024-02-06 오후 4 29 01" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/32007781/ce77daa9-9c33-4dac-8444-9d15c65a6fee">

Recommend 도메인 객체 soft delete 구현
<img width="567" alt="스크린샷 2024-02-06 오후 4 30 14" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/32007781/4806a298-2a65-4e5e-8610-1cb85ecc737e">
<img width="400" alt="스크린샷 2024-02-06 오후 4 30 23" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/32007781/d6482239-99de-4c05-b791-d6f6932b89a9">

## postman

주류 추천 요청 API (헤더의 Authroization부분에 토큰 입력)
<img width="1084" alt="스크린샷 2024-02-06 오후 4 32 26" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/32007781/a893cf5d-3c88-47fa-a791-0524cbfc3e21">


나의 주류 추천 리스트 API (헤더의 Authorization부분에 토큰 입력, 삭제시 삭제된 객체 출력되지 않음)
<img width="1077" alt="스크린샷 2024-02-06 오후 4 31 28" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/32007781/04ea13eb-4c10-413c-8e2e-edc854729f2b">


## 질문 및 이외 사항


-

## 이슈 번호

- close #102 