### PR TITLE
Fix: 오늘의 조합 API 수정 & 로그인 사용자 정보 어노테이션 추가 & Soft Delete 적용

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/Combination.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/Combination.java
@@ -4,6 +4,7 @@ package com.example.dgbackend.domain.combination;
 import com.example.dgbackend.domain.combinationcomment.CombinationComment;
 import com.example.dgbackend.domain.combinationimage.CombinationImage;
 import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.recommend.Recommend;
 import com.example.dgbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -58,6 +59,10 @@ public class Combination extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recommend_id")
+    private Recommend recommend;
+
     @OneToMany(mappedBy = "combination", cascade = CascadeType.ALL)
     private List<CombinationImage> combinationImages = new ArrayList<>();
 
@@ -82,9 +87,10 @@ public class Combination extends BaseTimeEntity {
     /**
      * update 함수
      */
-    public void updateCombination(String title, String content) {
+    public void updateCombination(String title, String content, Recommend recommend) {
         this.title = title;
         this.content = content;
+        this.recommend = recommend;
     }
 
     public void delete() {

--- a/src/main/java/com/example/dgbackend/domain/combination/Combination.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/Combination.java
@@ -87,6 +87,10 @@ public class Combination extends BaseTimeEntity {
         this.content = content;
     }
 
+    public void delete() {
+        this.state = false;
+    }
+
     /**
      * CombinationLike 관련 메서드
      */

--- a/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
@@ -4,25 +4,20 @@ import com.example.dgbackend.domain.combination.dto.CombinationRequest;
 import com.example.dgbackend.domain.combination.dto.CombinationResponse;
 import com.example.dgbackend.domain.combination.service.CombinationCommandService;
 import com.example.dgbackend.domain.combination.service.CombinationQueryService;
+import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.global.common.response.ApiResponse;
+import com.example.dgbackend.global.jwt.annotation.MemberObject;
 import com.example.dgbackend.global.validation.annotation.CheckPage;
 import com.example.dgbackend.global.validation.annotation.ExistCombination;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
 
 @Tag(name = "오늘의 조합 API")
 @RestController
@@ -39,10 +34,11 @@ public class CombinationController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 목록 조회 성공")
     })
     @Parameter(name = "page", description = "오늘의 조합 목록 페이지 번호, query string 입니다.")
-    @GetMapping("")
+    @GetMapping()
     public ApiResponse<CombinationResponse.CombinationPreviewResultList> getCombinations(
+        @MemberObject Member member,
         @CheckPage @RequestParam(name = "page") Integer page) {
-        return ApiResponse.onSuccess(combinationQueryService.getCombinationPreviewResultList(page));
+        return ApiResponse.onSuccess(combinationQueryService.getCombinationPreviewResultList(page, member));
     }
 
     @Operation(summary = "오늘의 조합 상세정보 조회", description = "특정 오늘의 조합 정보를 조회합니다.")
@@ -114,10 +110,10 @@ public class CombinationController {
 
     @Operation(summary = "내가 작성한 오늘의 조합 조회", description = "작성한 오늘의 조합 목록을 조회합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내가 작성한 오늘의 조합 목록 조회 성공")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내가 작성한 오늘의 조합 목록 조회 성공")
     })
     @GetMapping("/my-page")
-    public ApiResponse<CombinationResponse.CombinationMyPageList> getMyPageCombinations(@RequestParam(name="Member Id") Long memberId, @CheckPage @RequestParam(name = "page") Integer page) {
+    public ApiResponse<CombinationResponse.CombinationMyPageList> getMyPageCombinations(@RequestParam(name = "Member Id") Long memberId, @CheckPage @RequestParam(name = "page") Integer page) {
         return ApiResponse.onSuccess(combinationQueryService.getCombinationMyPageList(memberId, page));
     }
 
@@ -133,10 +129,10 @@ public class CombinationController {
 
     @Operation(summary = "내가 좋아요한 오늘의 조합 조회", description = "좋아요를 누른 오늘의 조합 목록을 조회합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내가 좋아요한 오늘의 조합 목록 조회 성공")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내가 좋아요한 오늘의 조합 목록 조회 성공")
     })
     @GetMapping("/likes")
-    public ApiResponse<CombinationResponse.CombinationMyPageList> getLikeCombinations(@RequestParam(name="Member Id") Long memberId, @CheckPage @RequestParam(name = "page") Integer page) {
+    public ApiResponse<CombinationResponse.CombinationMyPageList> getLikeCombinations(@RequestParam(name = "Member Id") Long memberId, @CheckPage @RequestParam(name = "page") Integer page) {
         return ApiResponse.onSuccess(combinationQueryService.getCombinationLikeList(memberId, page));
     }
 

--- a/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
@@ -87,9 +87,10 @@ public class CombinationController {
     })
     @Parameter(name = "combinationId", description = "오늘의 조합 Id, Path Variable 입니다.")
     @GetMapping("/{combinationId}/edit")
+    @CheckCombinationOwner
     public ApiResponse<CombinationResponse.CombinationEditResult> editCombination(
         @Parameter(hidden = true) @MemberObject Member loginMember,
-        @CheckCombinationOwner @ExistCombination @PathVariable(name = "combinationId") Long combinationId) {
+        @ExistCombination @PathVariable(name = "combinationId") Long combinationId) {
         return ApiResponse.onSuccess(
             combinationQueryService.getCombinationEditResult(combinationId, loginMember));
     }
@@ -100,6 +101,7 @@ public class CombinationController {
     })
     @Parameter(name = "combinationId", description = "오늘의 조합 Id, Path Variable 입니다.")
     @PatchMapping("/{combinationId}")
+    @CheckCombinationOwner
     public ApiResponse<CombinationResponse.CombinationProcResult> editProcCombination(
         @ExistCombination @PathVariable(name = "combinationId") Long combinationId,
         @RequestBody CombinationRequest.WriteCombination request)
@@ -114,6 +116,7 @@ public class CombinationController {
     })
     @Parameter(name = "combinationId", description = "오늘의 조합 Id, Path Variable 입니다.")
     @DeleteMapping("/{combinationId}")
+    @CheckCombinationOwner
     public ApiResponse<CombinationResponse.CombinationProcResult> deleteCombination(
         @ExistCombination @PathVariable(name = "combinationId") Long combinationId) {
 

--- a/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
@@ -102,7 +102,7 @@ public class CombinationController {
     @PatchMapping("/{combinationId}")
     public ApiResponse<CombinationResponse.CombinationProcResult> editProcCombination(
         @ExistCombination @PathVariable(name = "combinationId") Long combinationId,
-        @RequestPart(name = "writeCombination") CombinationRequest.WriteCombination request)
+        @RequestBody CombinationRequest.WriteCombination request)
         throws IOException {
         return ApiResponse.onSuccess(
             combinationCommandService.editCombination(combinationId, request));

--- a/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
@@ -68,15 +68,13 @@ public class CombinationController {
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 작성 성공")
     })
-    @Parameter(name = "recommendId", description = "내가 받은 추천 조합 Id, Path Variable 입니다.")
     @PostMapping("/recommends/{recommendId}")
     public ApiResponse<CombinationResponse.CombinationProcResult> writeCombination(
         @Parameter(hidden = true) @MemberObject Member loginMember,
-        @PathVariable(name = "recommendId") Long recommendId,
         @RequestBody CombinationRequest.WriteCombination request)
         throws IOException {
         return ApiResponse.onSuccess(
-            combinationCommandService.uploadCombination(recommendId, request, loginMember));
+            combinationCommandService.uploadCombination(request, loginMember));
 
     }
 

--- a/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -69,12 +70,12 @@ public class CombinationController {
     @Parameter(name = "recommendId", description = "내가 받은 추천 조합 Id, Path Variable 입니다.")
     @PostMapping("/recommends/{recommendId}")
     public ApiResponse<CombinationResponse.CombinationProcResult> writeCombination(
+        @Parameter(hidden = true) @MemberObject Member loginMember,
         @PathVariable(name = "recommendId") Long recommendId,
-        @RequestPart(name = "writeCombination") CombinationRequest.WriteCombination request)
+        @RequestBody CombinationRequest.WriteCombination request)
         throws IOException {
-        // TODO: HttpServletRequest 사용해서 Authorization token으로 사용자 정보 받아오기
         return ApiResponse.onSuccess(
-            combinationCommandService.uploadCombination(recommendId, request));
+            combinationCommandService.uploadCombination(recommendId, request, loginMember));
 
     }
 

--- a/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
@@ -13,11 +13,18 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
-
-import java.io.IOException;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "오늘의 조합 API")
 @RestController
@@ -36,9 +43,10 @@ public class CombinationController {
     @Parameter(name = "page", description = "오늘의 조합 목록 페이지 번호, query string 입니다.")
     @GetMapping()
     public ApiResponse<CombinationResponse.CombinationPreviewResultList> getCombinations(
-        @MemberObject Member member,
+        @Parameter(hidden = true) @MemberObject Member loginMember,
         @CheckPage @RequestParam(name = "page") Integer page) {
-        return ApiResponse.onSuccess(combinationQueryService.getCombinationPreviewResultList(page, member));
+        return ApiResponse.onSuccess(
+            combinationQueryService.getCombinationPreviewResultList(page, loginMember));
     }
 
     @Operation(summary = "오늘의 조합 상세정보 조회", description = "특정 오늘의 조합 정보를 조회합니다.")
@@ -48,9 +56,10 @@ public class CombinationController {
     @Parameter(name = "combinationId", description = "오늘의 조합 Id, Path Variable 입니다.")
     @GetMapping("/{combinationId}")
     public ApiResponse<CombinationResponse.CombinationDetailResult> getDetailCombination(
+        @Parameter(hidden = true) @MemberObject Member loginMember,
         @ExistCombination @PathVariable(name = "combinationId") Long combinationId) {
         return ApiResponse.onSuccess(
-            combinationQueryService.getCombinationDetailResult(combinationId));
+            combinationQueryService.getCombinationDetailResult(combinationId, loginMember));
     }
 
     @Operation(summary = "오늘의 조합 작성", description = "오늘의 조합 작성합니다.")

--- a/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
@@ -7,6 +7,7 @@ import com.example.dgbackend.domain.combination.service.CombinationQueryService;
 import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.global.common.response.ApiResponse;
 import com.example.dgbackend.global.jwt.annotation.MemberObject;
+import com.example.dgbackend.global.validation.annotation.CheckCombinationOwner;
 import com.example.dgbackend.global.validation.annotation.CheckPage;
 import com.example.dgbackend.global.validation.annotation.ExistCombination;
 import io.swagger.v3.oas.annotations.Operation;
@@ -87,9 +88,10 @@ public class CombinationController {
     @Parameter(name = "combinationId", description = "오늘의 조합 Id, Path Variable 입니다.")
     @GetMapping("/{combinationId}/edit")
     public ApiResponse<CombinationResponse.CombinationEditResult> editCombination(
-        @ExistCombination @PathVariable(name = "combinationId") Long combinationId) {
+        @Parameter(hidden = true) @MemberObject Member loginMember,
+        @CheckCombinationOwner @ExistCombination @PathVariable(name = "combinationId") Long combinationId) {
         return ApiResponse.onSuccess(
-            combinationQueryService.getCombinationEditResult(combinationId));
+            combinationQueryService.getCombinationEditResult(combinationId, loginMember));
     }
 
     @Operation(summary = "오늘의 조합 수정", description = "특정 오늘의 조합을 수정합니다.")

--- a/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
@@ -25,7 +25,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "오늘의 조합 API")
@@ -126,17 +125,21 @@ public class CombinationController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내가 작성한 오늘의 조합 목록 조회 성공")
     })
     @GetMapping("/my-page")
-    public ApiResponse<CombinationResponse.CombinationMyPageList> getMyPageCombinations(@RequestParam(name = "Member Id") Long memberId, @CheckPage @RequestParam(name = "page") Integer page) {
-        return ApiResponse.onSuccess(combinationQueryService.getCombinationMyPageList(memberId, page));
+    public ApiResponse<CombinationResponse.CombinationMyPageList> getMyPageCombinations(
+        @RequestParam(name = "Member Id") Long memberId,
+        @CheckPage @RequestParam(name = "page") Integer page) {
+        return ApiResponse.onSuccess(
+            combinationQueryService.getCombinationMyPageList(memberId, page));
     }
 
     @Operation(summary = "주간 베스트 조합 조회", description = "주간 베스트 조합 목록을 조회합니다.")
     @Parameter(name = "page", description = "주간 베스트 조합 목록 페이지 번호, query string 입니다.")
     @GetMapping("/weekly-best")
     public ApiResponse<CombinationResponse.CombinationPreviewResultList> getWeeklyBestCombinations(
+        @Parameter(hidden = true) @MemberObject Member loginMember,
         @CheckPage @RequestParam(name = "page") Integer page) {
         return ApiResponse.onSuccess(
-            combinationQueryService.getWeeklyBestCombinationPreviewResultList(page));
+            combinationQueryService.getWeeklyBestCombinationPreviewResultList(loginMember, page));
     }
 
 
@@ -145,23 +148,29 @@ public class CombinationController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내가 좋아요한 오늘의 조합 목록 조회 성공")
     })
     @GetMapping("/likes")
-    public ApiResponse<CombinationResponse.CombinationMyPageList> getLikeCombinations(@RequestParam(name = "Member Id") Long memberId, @CheckPage @RequestParam(name = "page") Integer page) {
-        return ApiResponse.onSuccess(combinationQueryService.getCombinationLikeList(memberId, page));
+    public ApiResponse<CombinationResponse.CombinationMyPageList> getLikeCombinations(
+        @RequestParam(name = "Member Id") Long memberId,
+        @CheckPage @RequestParam(name = "page") Integer page) {
+        return ApiResponse.onSuccess(
+            combinationQueryService.getCombinationLikeList(memberId, page));
     }
 
     @Operation(summary = "오늘의 조합 검색", description = "오늘의 조합 목록을 검색합니다.")
     @GetMapping("/search")
     public ApiResponse<CombinationResponse.CombinationPreviewResultList> findCombinationsListByKeyWord(
+        @Parameter(hidden = true) @MemberObject Member loginMember,
         @RequestParam(name = "page") Integer page, @RequestParam(name = "keyword") String keyword) {
         return ApiResponse.onSuccess(
-            combinationQueryService.findCombinationsListByKeyword(page, keyword));
+            combinationQueryService.findCombinationsListByKeyword(loginMember, page, keyword));
     }
 
     @Operation(summary = "주간 베스트 조합 검색", description = "주간 베스트 조합 목록을 검색합니다.")
     @GetMapping("/weekly-best/search")
     public ApiResponse<CombinationResponse.CombinationPreviewResultList> findWeeklyBestCombinationsListByKeyWord(
+        @Parameter(hidden = true) @MemberObject Member loginMember,
         @RequestParam(name = "page") Integer page, @RequestParam(name = "keyword") String keyword) {
         return ApiResponse.onSuccess(
-            combinationQueryService.findWeeklyBestCombinationsListByKeyWord(page, keyword));
+            combinationQueryService.findWeeklyBestCombinationsListByKeyWord(loginMember, page,
+                keyword));
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationRequest.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationRequest.java
@@ -1,6 +1,11 @@
 package com.example.dgbackend.domain.combination.dto;
 
+import com.example.dgbackend.domain.combination.Combination;
+import com.example.dgbackend.domain.combinationimage.CombinationImage;
+import com.example.dgbackend.domain.member.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 
 import java.util.List;
@@ -17,4 +22,20 @@ public class CombinationRequest {
         List<String> combinationImageList;
     }
 
+    public static Combination createCombination(Member member, String title, String content, String... imageUrls) {
+        Combination combination = Combination.builder()
+            .member(member)
+            .title(title)
+            .content(content)
+            .combinationImages(new ArrayList<>())
+            .build();
+
+        for (String imageUrl : imageUrls) {
+            CombinationImage combinationImage = CombinationImage.builder()
+                .imageUrl(imageUrl)
+                .build();
+            combination.addCombinationImage(combinationImage);
+        }
+        return combination;
+    }
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationRequest.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationRequest.java
@@ -16,6 +16,7 @@ public class CombinationRequest {
 
         String title;
         String content;
+        Long recommendId;
         List<String> hashTagNameList;
         List<String> combinationImageList;
     }

--- a/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationRequest.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationRequest.java
@@ -8,8 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 
-import java.util.List;
-
 public class CombinationRequest {
 
     @Getter

--- a/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationResponse.java
@@ -259,14 +259,15 @@ public class CombinationResponse {
     @NoArgsConstructor
     @Getter
     public static class CombinationProcResult {
+
         Long combinationId;
         LocalDateTime createdAt;
     }
 
     public static CombinationProcResult toCombinationProcResult(Long combinationId) {
         return CombinationProcResult.builder()
-                .combinationId(combinationId)
-                .createdAt(LocalDateTime.now())
-                .build();
+            .combinationId(combinationId)
+            .createdAt(LocalDateTime.now())
+            .build();
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationResponse.java
@@ -225,30 +225,33 @@ public class CombinationResponse {
     @NoArgsConstructor
     @Getter
     public static class CombinationEditResult {
+
         String title;
         String content;
         List<String> hashTagList;
         List<String> combinationImageUrlList;
+        Long recommendId;
     }
 
     public static CombinationEditResult toCombinationEditResult(Combination combination,
-                                                                List<HashTagOption> hashTagOptions,
-                                                                List<CombinationImage> combinationImages) {
+        List<HashTagOption> hashTagOptions,
+        List<CombinationImage> combinationImages) {
 
         List<String> hashTagList = hashTagOptions.stream()
-                .map(hto -> hto.getHashTag().getName())
-                .toList();
+            .map(hto -> hto.getHashTag().getName())
+            .toList();
 
         List<String> combinationImageUrlList = combinationImages.stream()
-                .map(CombinationImage::getImageUrl)
-                .toList();
+            .map(CombinationImage::getImageUrl)
+            .toList();
 
         return CombinationEditResult.builder()
-                .title(combination.getTitle())
-                .content(combination.getContent())
-                .hashTagList(hashTagList)
-                .combinationImageUrlList(combinationImageUrlList)
-                .build();
+            .title(combination.getTitle())
+            .content(combination.getContent())
+            .hashTagList(hashTagList)
+            .combinationImageUrlList(combinationImageUrlList)
+            .recommendId(combination.getRecommend().getId())
+            .build();
     }
 
     /**

--- a/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationResponse.java
@@ -5,16 +5,15 @@ import com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentRes
 import com.example.dgbackend.domain.combinationimage.CombinationImage;
 import com.example.dgbackend.domain.hashtagoption.HashTagOption;
 import com.example.dgbackend.domain.member.dto.MemberResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public class CombinationResponse {
 
@@ -26,6 +25,7 @@ public class CombinationResponse {
     @NoArgsConstructor
     @Getter
     public static class CombinationPreviewResultList {
+
         List<CombinationPreviewResult> combinationList;
         Integer listSize;
         Integer totalPage;
@@ -39,6 +39,7 @@ public class CombinationResponse {
     @NoArgsConstructor
     @Getter
     public static class CombinationPreviewResult {
+
         Long combinationId;
         String title;
         String combinationImageUrl;
@@ -49,49 +50,52 @@ public class CombinationResponse {
     }
 
     // Page<Combination> -> Page<CombinationPreviewDTO> 로 변환
-    public static CombinationPreviewResultList toCombinationPreviewResultList(Page<Combination> combinations,
-                                                                              List<List<HashTagOption>> hashTagOptions,
-                                                                              List<Boolean> isLikes) {
+    public static CombinationPreviewResultList toCombinationPreviewResultList(
+        Page<Combination> combinations,
+        List<List<HashTagOption>> hashTagOptions,
+        List<Boolean> isLikes) {
 
-        List<CombinationPreviewResult> combinationPreviewDTOS = IntStream.range(0, combinations.getContent().size())
-                .mapToObj(i -> toCombinationPreviewResult(combinations.getContent().get(i), hashTagOptions.get(i), isLikes.get(i)))
-                .collect(Collectors.toList());
+        List<CombinationPreviewResult> combinationPreviewDTOS = IntStream.range(0,
+                combinations.getContent().size())
+            .mapToObj(i -> toCombinationPreviewResult(combinations.getContent().get(i),
+                hashTagOptions.get(i), isLikes.get(i)))
+            .collect(Collectors.toList());
 
         return CombinationPreviewResultList.builder()
-                .combinationList(combinationPreviewDTOS)
-                .listSize(combinationPreviewDTOS.size())
-                .totalPage(combinations.getTotalPages())
-                .totalElements(combinations.getTotalElements())
-                .isFirst(combinations.isFirst())
-                .isLast(combinations.isLast())
-                .build();
+            .combinationList(combinationPreviewDTOS)
+            .listSize(combinationPreviewDTOS.size())
+            .totalPage(combinations.getTotalPages())
+            .totalElements(combinations.getTotalElements())
+            .isFirst(combinations.isFirst())
+            .isLast(combinations.isLast())
+            .build();
     }
 
     // Combination -> CombinationPreviewDTO로 변환
     public static CombinationPreviewResult toCombinationPreviewResult(Combination combination,
-                                                                      List<HashTagOption> hashTagOptions,
-                                                                      Boolean isLike) {
+        List<HashTagOption> hashTagOptions,
+        Boolean isLike) {
         // TODO: 대표 이미지 정하기
         String imageUrl = combination.getCombinationImages()
-                .stream()
-                .findFirst()
-                .map(CombinationImage::getImageUrl)
-                .orElse(null);
+            .stream()
+            .findFirst()
+            .map(CombinationImage::getImageUrl)
+            .orElse(null);
 
         // 해시태그 정보
         List<String> hashTagList = hashTagOptions.stream()
-                .map(hto -> hto.getHashTag().getName())
-                .collect(Collectors.toList());
+            .map(hto -> hto.getHashTag().getName())
+            .collect(Collectors.toList());
 
         return CombinationPreviewResult.builder()
-                .combinationId(combination.getId())
-                .title(combination.getTitle())
-                .combinationImageUrl(imageUrl)
-                .likeCount(combination.getLikeCount())
-                .commentCount(combination.getCommentCount())
-                .hashTageList(hashTagList)
-                .isLike(isLike)
-                .build();
+            .combinationId(combination.getId())
+            .title(combination.getTitle())
+            .combinationImageUrl(imageUrl)
+            .likeCount(combination.getLikeCount())
+            .commentCount(combination.getCommentCount())
+            .hashTageList(hashTagList)
+            .isLike(isLike)
+            .build();
     }
 
     /**
@@ -161,19 +165,21 @@ public class CombinationResponse {
     @NoArgsConstructor
     @Getter
     public static class CombinationDetailResult {
+
         CombinationResult combinationResult;
         MemberResponse.MemberResult memberResult;
         CombinationCommentResponse.CommentPreViewResult combinationCommentResult;
     }
 
-    public static CombinationDetailResult toCombinationDetailResult(CombinationResult combinationResult,
-                                                                    MemberResponse.MemberResult memberResult,
-                                                                    CombinationCommentResponse.CommentPreViewResult combinationCommentResult) {
+    public static CombinationDetailResult toCombinationDetailResult(
+        CombinationResult combinationResult,
+        MemberResponse.MemberResult memberResult,
+        CombinationCommentResponse.CommentPreViewResult combinationCommentResult) {
         return CombinationDetailResult.builder()
-                .combinationResult(combinationResult)
-                .memberResult(memberResult)
-                .combinationCommentResult(combinationCommentResult)
-                .build();
+            .combinationResult(combinationResult)
+            .memberResult(memberResult)
+            .combinationCommentResult(combinationCommentResult)
+            .build();
     }
 
     @Builder
@@ -181,6 +187,7 @@ public class CombinationResponse {
     @NoArgsConstructor
     @Getter
     public static class CombinationResult {
+
         Long combinationId;
         String title;
         String content;
@@ -190,24 +197,24 @@ public class CombinationResponse {
     }
 
     public static CombinationResult toCombinationResult(Combination combination,
-                                                        List<HashTagOption> hashTagOptions,
-                                                        boolean isCombinationLike) {
+        List<HashTagOption> hashTagOptions,
+        boolean isCombinationLike) {
         List<String> hashTagList = hashTagOptions.stream()
-                .map(hto -> hto.getHashTag().getName())
-                .toList();
+            .map(hto -> hto.getHashTag().getName())
+            .toList();
 
         List<String> imageList = combination.getCombinationImages().stream()
-                .map(CombinationImage::getImageUrl)
-                .toList();
+            .map(CombinationImage::getImageUrl)
+            .toList();
 
         return CombinationResult.builder()
-                .combinationId(combination.getId())
-                .title(combination.getTitle())
-                .content(combination.getContent())
-                .hashTagList(hashTagList)
-                .combinationImageList(imageList)
-                .isCombinationLike(isCombinationLike)
-                .build();
+            .combinationId(combination.getId())
+            .title(combination.getTitle())
+            .content(combination.getContent())
+            .hashTagList(hashTagList)
+            .combinationImageList(imageList)
+            .isCombinationLike(isCombinationLike)
+            .build();
     }
 
     /**

--- a/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
@@ -2,19 +2,21 @@ package com.example.dgbackend.domain.combination.repository;
 
 import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.member.Member;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
-
 public interface CombinationRepository extends JpaRepository<Combination, Long> {
+
     Page<Combination> findAllByMemberId(Long memberId, PageRequest pageRequest);
 
     List<Combination> findAllByMember(Member member);
 
     Page<Combination> findAllByState(Boolean state, PageRequest pageRequest);
+
+    Boolean existsByIdAndMember(Long combinationId, Member member);
 
     Page<Combination> findCombinationsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
         Long likeCount, PageRequest pageRequest);

--- a/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
@@ -14,6 +14,8 @@ public interface CombinationRepository extends JpaRepository<Combination, Long> 
 
     List<Combination> findAllByMember(Member member);
 
+    Page<Combination> findAllByState(Boolean state, PageRequest pageRequest);
+
     Page<Combination> findCombinationsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
         Long likeCount, PageRequest pageRequest);
 

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandService.java
@@ -2,14 +2,17 @@ package com.example.dgbackend.domain.combination.service;
 
 import com.example.dgbackend.domain.combination.dto.CombinationRequest.WriteCombination;
 import com.example.dgbackend.domain.combination.dto.CombinationResponse;
+import com.example.dgbackend.domain.member.Member;
 
 public interface CombinationCommandService {
 
-    CombinationResponse.CombinationProcResult uploadCombination(Long recommendId, WriteCombination request);
+    CombinationResponse.CombinationProcResult uploadCombination(Long recommendId,
+        WriteCombination request, Member loginMember);
 
     CombinationResponse.CombinationProcResult deleteCombination(Long combinationId);
 
-    CombinationResponse.CombinationProcResult editCombination(Long combinationId, WriteCombination request);
+    CombinationResponse.CombinationProcResult editCombination(Long combinationId,
+        WriteCombination request);
 
     boolean deleteAllCombination(Long memberId);
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandService.java
@@ -6,8 +6,8 @@ import com.example.dgbackend.domain.member.Member;
 
 public interface CombinationCommandService {
 
-    CombinationResponse.CombinationProcResult uploadCombination(Long recommendId,
-        WriteCombination request, Member loginMember);
+    CombinationResponse.CombinationProcResult uploadCombination(WriteCombination request,
+        Member loginMember);
 
     CombinationResponse.CombinationProcResult deleteCombination(Long combinationId);
 

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandServiceImpl.java
@@ -43,7 +43,7 @@ public class CombinationCommandServiceImpl implements CombinationCommandService 
      * 오늘의 조합 작성
      */
     @Override
-    public CombinationResponse.CombinationProcResult uploadCombination(Long recommendId,
+    public CombinationResponse.CombinationProcResult uploadCombination(
         CombinationRequest.WriteCombination request, Member loginMember) {
 
         // Combination & CombinationImage
@@ -52,7 +52,7 @@ public class CombinationCommandServiceImpl implements CombinationCommandService 
 
         // 업로드 이미지가 없는 경우, GPT가 추천해준 이미지 사용
         if (combinationImageList == null || combinationImageList.isEmpty()) {
-            Recommend recommend = recommendQueryService.getRecommend(recommendId);
+            Recommend recommend = recommendQueryService.getRecommend(request.getRecommendId());
             String recommendImageUrl = recommend.getImageUrl();
 
             newCombination = createCombination(loginMember, request.getTitle(),

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandServiceImpl.java
@@ -112,7 +112,7 @@ public class CombinationCommandServiceImpl implements CombinationCommandService 
     @Override
     public boolean deleteAllCombination(Long memberId) {
         Member member = memberRepository.findById(memberId).orElseThrow(
-                () -> new ApiException(ErrorStatus._EMPTY_MEMBER)
+            () -> new ApiException(ErrorStatus._EMPTY_MEMBER)
         );
         List<Combination> combinationList = combinationRepository.findAllByMember(member);
         for (Combination combination : combinationList) {

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandServiceImpl.java
@@ -69,21 +69,6 @@ public class CombinationCommandServiceImpl implements CombinationCommandService 
         return CombinationResponse.toCombinationProcResult(saveCombination.getId());
     }
 
-    private Combination createCombination(String title, String content, String... imageUrls) {
-        Combination combination = Combination.builder()
-                .title(title)
-                .content(content)
-                .combinationImages(new ArrayList<>())
-                .build();
-
-        for (String imageUrl : imageUrls) {
-            CombinationImage combinationImage = CombinationImage.builder()
-                    .imageUrl(imageUrl)
-                    .build();
-            combination.addCombinationImage(combinationImage);
-        }
-        return combination;
-    }
 
     /**
      * 오늘의 조합 삭제

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandServiceImpl.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CombinationCommandServiceImpl implements CombinationCommandService {
 
     private final CombinationRepository combinationRepository;
+    private final CombinationQueryService combinationQueryService;
     private final RecommendRepository recommendRepository;
     private final S3Service s3Service;
     private final HashTagCommandService hashTagCommandService;
@@ -76,18 +77,9 @@ public class CombinationCommandServiceImpl implements CombinationCommandService 
     @Override
     public CombinationResponse.CombinationProcResult deleteCombination(Long combinationId) {
 
-        // HashTagOption 삭제
-        hashTagOptionCommandService.deleteHashTagOption(combinationId);
+        // soft delete 적용
+        combinationQueryService.getCombination(combinationId).delete();
 
-        // CombinationLike 삭제
-        combinationLikeCommandService.deleteCombinationLike(combinationId);
-
-        // S3에 해당 Combination 이미지 삭제
-        List<String> imageUrls = combinationImageQueryService.getCombinationImageUrl(combinationId);
-        deleteS3Image(imageUrls);
-
-        // combination 삭제 - 양방향 매핑 CombinationImage, CombinationComment 함께 삭제
-        combinationRepository.deleteById(combinationId);
         return CombinationResponse.toCombinationProcResult(combinationId);
     }
 

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
@@ -1,15 +1,13 @@
 package com.example.dgbackend.domain.combination.service;
 
-import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationDetailResult;
-import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationEditResult;
-import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationPreviewResultList;
-import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationMyPageList;
-
 import com.example.dgbackend.domain.combination.Combination;
+import com.example.dgbackend.domain.member.Member;
+
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.*;
 
 public interface CombinationQueryService {
 
-    CombinationPreviewResultList getCombinationPreviewResultList(Integer page);
+    CombinationPreviewResultList getCombinationPreviewResultList(Integer page, Member member);
 
     CombinationDetailResult getCombinationDetailResult(Long combinationId);
 
@@ -29,7 +27,7 @@ public interface CombinationQueryService {
     CombinationPreviewResultList findCombinationsListByKeyword(Integer page, String keyword);
 
     CombinationPreviewResultList findWeeklyBestCombinationsListByKeyWord(Integer page,
-        String keyword);
+                                                                         String keyword);
 
 
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
@@ -17,6 +17,8 @@ public interface CombinationQueryService {
 
     Combination getCombination(Long combinationId);
 
+    Combination isDelete(Combination combination);
+
     CombinationMyPageList getCombinationMyPageList(Long memberId, Integer page);
 
     CombinationPreviewResultList getWeeklyBestCombinationPreviewResultList(Integer page);

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
@@ -8,8 +8,6 @@ import static com.example.dgbackend.domain.combination.dto.CombinationResponse.C
 import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.member.Member;
 
-import static com.example.dgbackend.domain.combination.dto.CombinationResponse.*;
-
 public interface CombinationQueryService {
 
     CombinationPreviewResultList getCombinationPreviewResultList(Integer page, Member loginMember);
@@ -28,15 +26,18 @@ public interface CombinationQueryService {
 
     CombinationMyPageList getCombinationMyPageList(Long memberId, Integer page);
 
-    CombinationPreviewResultList getWeeklyBestCombinationPreviewResultList(Integer page);
+    CombinationPreviewResultList getWeeklyBestCombinationPreviewResultList(Member loginMember,
+        Integer page);
 
 
     CombinationMyPageList getCombinationLikeList(Long memberId, Integer page);
 
-    CombinationPreviewResultList findCombinationsListByKeyword(Integer page, String keyword);
+    CombinationPreviewResultList findCombinationsListByKeyword(Member loginMember, Integer page,
+        String keyword);
 
-    CombinationPreviewResultList findWeeklyBestCombinationsListByKeyWord(Integer page,
-                                                                         String keyword);
+    CombinationPreviewResultList findWeeklyBestCombinationsListByKeyWord(Member loginMember,
+        Integer page,
+        String keyword);
 
 
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
@@ -1,5 +1,10 @@
 package com.example.dgbackend.domain.combination.service;
 
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationDetailResult;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationEditResult;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationMyPageList;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationPreviewResultList;
+
 import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.member.Member;
 
@@ -11,13 +16,15 @@ public interface CombinationQueryService {
 
     CombinationDetailResult getCombinationDetailResult(Long combinationId, Member loginMember);
 
-    CombinationEditResult getCombinationEditResult(Long combinationId);
+    CombinationEditResult getCombinationEditResult(Long combinationId, Member loginMember);
 
     boolean existCombination(Long combinationId);
 
     Combination getCombination(Long combinationId);
 
     Combination isDelete(Combination combination);
+
+    Boolean isCombinationOwner(Long combinationId, Member member);
 
     CombinationMyPageList getCombinationMyPageList(Long memberId, Integer page);
 

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
@@ -7,9 +7,9 @@ import static com.example.dgbackend.domain.combination.dto.CombinationResponse.*
 
 public interface CombinationQueryService {
 
-    CombinationPreviewResultList getCombinationPreviewResultList(Integer page, Member member);
+    CombinationPreviewResultList getCombinationPreviewResultList(Integer page, Member loginMember);
 
-    CombinationDetailResult getCombinationDetailResult(Long combinationId);
+    CombinationDetailResult getCombinationDetailResult(Long combinationId, Member loginMember);
 
     CombinationEditResult getCombinationEditResult(Long combinationId);
 

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -147,64 +147,82 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
      * 내가 작성한 오늘의 조합 조회
      */
     @Override
-    public CombinationResponse.CombinationMyPageList getCombinationMyPageList(Long memberId, Integer page) {
-        Page<Combination> combinations = combinationRepository.findAllByMemberId(memberId, PageRequest.of(page, 9));
+    public CombinationResponse.CombinationMyPageList getCombinationMyPageList(Long memberId,
+        Integer page) {
+        Page<Combination> combinations = combinationRepository.findAllByMemberId(memberId,
+            PageRequest.of(page, 9));
 
         return toCombinationMyPageList(combinations);
     }
 
     @Override
-    public CombinationPreviewResultList getWeeklyBestCombinationPreviewResultList(Integer page) {
+    public CombinationPreviewResultList getWeeklyBestCombinationPreviewResultList(
+        Member loginMember, Integer page) {
         PageRequest pageRequest = PageRequest.of(page, 10);
         Page<Combination> combinations = combinationRepository.findCombinationsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
-                30L, pageRequest);
+            30L, pageRequest);
 
         List<Combination> combinationList = combinations.getContent();
         List<List<HashTagOption>> hashTagOptionList = combinationList.stream()
-                .map(hashTagOptionRepository::findAllByCombinationWithFetch)
-                .toList();
+            .map(hashTagOptionQueryService::getAllHashTagOptionByCombination)
+            .toList();
 
-        return toCombinationPreviewResultList(combinations, hashTagOptionList);
+        List<Boolean> isLikeList = combinationList.stream()
+            .map(cb -> combinationLikeQueryService.isCombinationLike(cb, loginMember))
+            .toList();
+
+        return toCombinationPreviewResultList(combinations, hashTagOptionList, isLikeList);
     }
 
     @Override
     public CombinationMyPageList getCombinationLikeList(Long memberId, Integer page) {
-        Page<Combination> combinations = combinationRepository.findCombinationsByMemberId(memberId, PageRequest.of(page, 9));
+        Page<Combination> combinations = combinationRepository.findCombinationsByMemberId(memberId,
+            PageRequest.of(page, 9));
 
         return toCombinationMyPageList(combinations);
     }
 
 
     @Override
-    public CombinationPreviewResultList findCombinationsListByKeyword(Integer page,
-                                                                      String keyword) {
+    public CombinationPreviewResultList findCombinationsListByKeyword(Member loginMember,
+        Integer page,
+        String keyword) {
         PageRequest pageRequest = PageRequest.of(page, 10);
 
         Page<Combination> combinations = combinationRepository.findCombinationsByTitleContaining(
-                keyword, pageRequest);
+            keyword, pageRequest);
 
         List<Combination> combinationList = combinations.getContent();
         List<List<HashTagOption>> hashTagOptionList = combinationList.stream()
-                .map(hashTagOptionRepository::findAllByCombinationWithFetch)
-                .toList();
+            .map(hashTagOptionQueryService::getAllHashTagOptionByCombination)
+            .toList();
 
-        return toCombinationPreviewResultList(combinations, hashTagOptionList);
+        List<Boolean> isLikeList = combinationList.stream()
+            .map(cb -> combinationLikeQueryService.isCombinationLike(cb, loginMember))
+            .toList();
+
+        return toCombinationPreviewResultList(combinations, hashTagOptionList, isLikeList);
     }
 
     @Override
-    public CombinationPreviewResultList findWeeklyBestCombinationsListByKeyWord(Integer page,
-                                                                                String keyword) {
+    public CombinationPreviewResultList findWeeklyBestCombinationsListByKeyWord(Member loginMember,
+        Integer page,
+        String keyword) {
         PageRequest pageRequest = PageRequest.of(page, 10);
 
         Page<Combination> combinations = combinationRepository.findCombinationsByTitleContainingAndLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
-                keyword, pageRequest, 30L);
+            keyword, pageRequest, 30L);
 
         List<Combination> combinationList = combinations.getContent();
         List<List<HashTagOption>> hashTagOptionList = combinationList.stream()
-                .map(hashTagOptionRepository::findAllByCombinationWithFetch)
-                .toList();
+            .map(hashTagOptionQueryService::getAllHashTagOptionByCombination)
+            .toList();
 
-        return toCombinationPreviewResultList(combinations, hashTagOptionList);
+        List<Boolean> isLikeList = combinationList.stream()
+            .map(cb -> combinationLikeQueryService.isCombinationLike(cb, loginMember))
+            .toList();
+
+        return toCombinationPreviewResultList(combinations, hashTagOptionList, isLikeList);
     }
 }
 

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -49,9 +49,10 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
     @Override
     public CombinationPreviewResultList getCombinationPreviewResultList(Integer page,
         Member loginMember) {
-        Page<Combination> combinations = combinationRepository.findAll(PageRequest.of(page, 10));
-
+        Page<Combination> combinations = combinationRepository.findAllByState(true,
+            PageRequest.of(page, 10));
         List<Combination> combinationList = combinations.getContent();
+
         List<List<HashTagOption>> hashTagOptionList = combinationList.stream()
             .map(hashTagOptionQueryService::getAllHashTagOptionByCombination)
             .toList();
@@ -71,9 +72,7 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
         Member loginMember) {
 
         // Combination
-        Combination combination = combinationRepository.findById(combinationId).orElseThrow(
-            () -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND)
-        );
+        Combination combination = getCombination(combinationId);
 
         // CombinationLike
         boolean isCombinationLike = combinationLikeQueryService.isCombinationLike(combination,

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -99,19 +99,17 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
      * 오늘의 조합 수정 정보 조회
      */
     @Override
-    public CombinationEditResult getCombinationEditResult(Long combinationId) {
+    public CombinationEditResult getCombinationEditResult(Long combinationId, Member member) {
 
-        Combination combination = combinationRepository.findById(combinationId).orElseThrow(
-                () -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND)
-        );
+        Combination combination = getCombination(combinationId);
 
         List<CombinationImage> combinationImages = combination.getCombinationImages();
 
-        List<HashTagOption> hashTagOptions = hashTagOptionRepository.findAllByCombinationWithFetch(
-                combination);
+        List<HashTagOption> hashTagOptions = hashTagOptionQueryService.getAllHashTagOptionByCombination(
+            combination);
 
         return CombinationResponse.toCombinationEditResult(combination, hashTagOptions,
-                combinationImages);
+            combinationImages);
     }
 
     @Override
@@ -138,6 +136,11 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
             throw new ApiException(ErrorStatus._DELETE_COMBINATION);
         }
         return combination;
+    }
+
+    @Override
+    public Boolean isCombinationOwner(Long combinationId, Member member) {
+        return combinationRepository.existsByIdAndMember(combinationId, member);
     }
 
     /*

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -1,5 +1,17 @@
 package com.example.dgbackend.domain.combination.service;
 
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationDetailResult;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationEditResult;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationMyPageList;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationPreviewResultList;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationResult;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.toCombinationDetailResult;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.toCombinationMyPageList;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.toCombinationPreviewResultList;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.toCombinationResult;
+import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentPreViewResult;
+import static com.example.dgbackend.domain.member.dto.MemberResponse.toMemberResult;
+
 import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.combination.dto.CombinationResponse;
 import com.example.dgbackend.domain.combination.repository.CombinationRepository;
@@ -14,6 +26,7 @@ import com.example.dgbackend.domain.member.dto.MemberResponse;
 import com.example.dgbackend.domain.member.repository.MemberRepository;
 import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
 import com.example.dgbackend.global.exception.ApiException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -42,7 +55,8 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
     오늘의 조합 홈 조회(페이징)
      */
     @Override
-    public CombinationPreviewResultList getCombinationPreviewResultList(Integer page, Member loginMember) {
+    public CombinationPreviewResultList getCombinationPreviewResultList(Integer page,
+        Member loginMember) {
         Page<Combination> combinations = combinationRepository.findAll(PageRequest.of(page, 10));
 
         List<Combination> combinationList = combinations.getContent();
@@ -61,7 +75,8 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
      * 오늘의 조합 상세 조회
      */
     @Override
-    public CombinationDetailResult getCombinationDetailResult(Long combinationId, Member loginMember) {
+    public CombinationDetailResult getCombinationDetailResult(Long combinationId,
+        Member loginMember) {
 
         // Combination
         Combination combination = combinationRepository.findById(combinationId).orElseThrow(

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -125,9 +125,20 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
      */
     @Override
     public Combination getCombination(Long combinationId) {
-        return combinationRepository.findById(combinationId).orElseThrow(
-                () -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND)
+        Combination combination = combinationRepository.findById(combinationId).orElseThrow(
+            () -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND)
         );
+
+        return isDelete(combination);
+    }
+
+    @Override
+    public Combination isDelete(Combination combination) {
+
+        if (!combination.isState()) {
+            throw new ApiException(ErrorStatus._DELETE_COMBINATION);
+        }
+        return combination;
     }
 
     /*

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -23,7 +23,6 @@ import com.example.dgbackend.domain.hashtagoption.repository.HashTagOptionReposi
 import com.example.dgbackend.domain.hashtagoption.service.HashTagOptionQueryService;
 import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.member.dto.MemberResponse;
-import com.example.dgbackend.domain.member.repository.MemberRepository;
 import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
 import com.example.dgbackend.global.exception.ApiException;
 import java.util.List;
@@ -33,12 +32,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
-import static com.example.dgbackend.domain.combination.dto.CombinationResponse.*;
-import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentPreViewResult;
-import static com.example.dgbackend.domain.member.dto.MemberResponse.toMemberResult;
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -47,7 +40,6 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
     private final CombinationRepository combinationRepository;
     private final HashTagOptionRepository hashTagOptionRepository;
     private final CombinationCommentQueryService combinationCommentQueryService;
-    private final MemberRepository memberRepository;
     private final CombinationLikeQueryService combinationLikeQueryService;
     private final HashTagOptionQueryService hashTagOptionQueryService;
 
@@ -82,9 +74,6 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
         Combination combination = combinationRepository.findById(combinationId).orElseThrow(
             () -> new ApiException(ErrorStatus._COMBINATION_NOT_FOUND)
         );
-
-        // TODO : Login Member 추후에 Token을 통해 정보 얻기
-        Member loginMember = memberRepository.findById(1L).get();
 
         // CombinationLike
         boolean isCombinationLike = combinationLikeQueryService.isCombinationLike(combination,

--- a/src/main/java/com/example/dgbackend/domain/hashtagoption/service/HashTagOptionQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/hashtagoption/service/HashTagOptionQueryService.java
@@ -1,0 +1,11 @@
+package com.example.dgbackend.domain.hashtagoption.service;
+
+import com.example.dgbackend.domain.combination.Combination;
+import com.example.dgbackend.domain.hashtagoption.HashTagOption;
+
+import java.util.List;
+
+public interface HashTagOptionQueryService {
+
+    List<HashTagOption> getAllHashTagOptionByCombination(Combination combination);
+}

--- a/src/main/java/com/example/dgbackend/domain/hashtagoption/service/HashTagOptionQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/hashtagoption/service/HashTagOptionQueryServiceImpl.java
@@ -1,0 +1,23 @@
+package com.example.dgbackend.domain.hashtagoption.service;
+
+import com.example.dgbackend.domain.combination.Combination;
+import com.example.dgbackend.domain.hashtagoption.HashTagOption;
+import com.example.dgbackend.domain.hashtagoption.repository.HashTagOptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class HashTagOptionQueryServiceImpl implements HashTagOptionQueryService {
+
+    private final HashTagOptionRepository hashTagOptionRepository;
+
+    @Override
+    public List<HashTagOption> getAllHashTagOptionByCombination(Combination combination) {
+        return hashTagOptionRepository.findAllByCombinationWithFetch(combination);
+    }
+}

--- a/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendQueryService.java
@@ -1,6 +1,7 @@
 package com.example.dgbackend.domain.recommend.service;
 
 import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.recommend.Recommend;
 import com.example.dgbackend.domain.recommend.dto.RecommendRequest;
 import com.example.dgbackend.domain.recommend.dto.RecommendResponse;
 
@@ -9,6 +10,8 @@ import static com.example.dgbackend.domain.recommend.dto.RecommendResponse.Recom
 public interface RecommendQueryService {
 
     void addRecommend(Member member, RecommendRequest.RecommendRequestDTO recommendRequestDTO, String drinkName, String drinkInfo, String imageUrl);
+
+    Recommend getRecommend(Long recommendId);
 
     RecommendResult getRecommendResult(Long recommendId);
 

--- a/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendQueryServiceImpl.java
@@ -15,12 +15,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class RecommendQueryServiceImpl implements RecommendQueryService {
+
     private final RecommendRepository recommendRepository;
     private final MemberRepository memberRepository;
     private final S3Service s3Service;
@@ -43,12 +42,15 @@ public class RecommendQueryServiceImpl implements RecommendQueryService {
     @Override
     public RecommendResponse.RecommendResult getRecommendResult(Long recommendId) {
 
-        Recommend recommend = recommendRepository.findById(recommendId).orElseThrow(
-                () -> new ApiException(ErrorStatus._RECOMMEND_NOT_FOUND)
+        return RecommendResponse.toRecommendResult(getRecommend(recommendId));
+
+    }
+
+    @Override
+    public Recommend getRecommend(Long recommendId) {
+        return recommendRepository.findById(recommendId).orElseThrow(
+            () -> new ApiException(ErrorStatus._RECOMMEND_NOT_FOUND)
         );
-
-        return RecommendResponse.toRecommendResult(recommend);
-
     }
 
     @Override

--- a/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
@@ -17,6 +17,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //멤버 관련
     _EMPTY_MEMBER(HttpStatus.CONFLICT, "MEMBER_001", "존재하지 않는 사용자입니다."),
+    _FORBIDDEN_MEMBER_REQUEST(HttpStatus.FORBIDDEN, "MEMBER_002", "해당 사용자는 금지된 요청을 하였습니다."),
 
     //오늘의 조합 관련
     _COMBINATION_NOT_FOUND(HttpStatus.NOT_FOUND, "COMBINATION_001", "존재하지 않는 오늘의 조합입니다."),

--- a/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
@@ -20,6 +20,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //오늘의 조합 관련
     _COMBINATION_NOT_FOUND(HttpStatus.NOT_FOUND, "COMBINATION_001", "존재하지 않는 오늘의 조합입니다."),
+    _DELETE_COMBINATION(HttpStatus.BAD_REQUEST, "COMBINATION_002", "삭제된 오늘의 조합입니다."),
 
     //오늘의 조합 댓글
     _COMBINATION_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMBINATION_COMMENT_001", "존재하지 않는 오늘의 조합 댓글입니다."),

--- a/src/main/java/com/example/dgbackend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/dgbackend/global/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package com.example.dgbackend.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,15 +14,31 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+
+        String jwtSchemeName = "JWT TOKEN";
+
+        // API 요청 헤더에 인증정보 포함
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        //SecuritySchemes 등록
+        Components components = new Components()
+            .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                .name(jwtSchemeName)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT"));
+
         return new OpenAPI()
-                .addServersItem(new Server().url("/"))
-                .info(apiInfo());
+            .addServersItem(new Server().url("/"))
+            .info(apiInfo())
+            .addSecurityItem(securityRequirement)
+            .components(components);
     }
 
     private Info apiInfo() {
         return new Info()
-                .title("음주미식회 Springdoc 테스트")
-                .description("Springdoc을 사용한 음주미식회 Swagger UI 테스트")
-                .version("1.0.0");
+            .title("음주미식회 Springdoc 테스트")
+            .description("Springdoc을 사용한 음주미식회 Swagger UI 테스트")
+            .version("1.0.0");
     }
 }

--- a/src/main/java/com/example/dgbackend/global/jwt/JwtProvider.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/JwtProvider.java
@@ -175,11 +175,12 @@ public class JwtProvider {
     // Access Token을 Header에서 추출
     public String getJwtTokenFromHeader(HttpServletRequest request) {
         String authorizationHeader = request.getHeader("Authorization");
-        log.info("-------------------------Authorization Header: " + authorizationHeader);
-        if (authorizationHeader != null) {
-            return authorizationHeader;
+
+        if (authorizationHeader == null) {
+            throw new ApiException(ErrorStatus._EMPTY_JWT);
         }
-        return null;
+        log.info("-------------------------Authorization Header: " + authorizationHeader);
+        return authorizationHeader;
     }
 
 

--- a/src/main/java/com/example/dgbackend/global/jwt/config/WebConfig.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/config/WebConfig.java
@@ -1,19 +1,29 @@
 package com.example.dgbackend.global.jwt.config;
 
 import com.example.dgbackend.global.jwt.resolver.MemberArgumentResolver;
+
+import com.example.dgbackend.global.validation.interceptor.CheckCombinationOwnerInterceptor;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
     private final MemberArgumentResolver memberArgumentResolver;
+    private final CheckCombinationOwnerInterceptor checkCombinationOwnerInterceptor;
+
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(memberArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(checkCombinationOwnerInterceptor);
     }
 }

--- a/src/main/java/com/example/dgbackend/global/jwt/controller/JwtController.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/controller/JwtController.java
@@ -1,18 +1,22 @@
 package com.example.dgbackend.global.jwt.controller;
 
+import com.example.dgbackend.global.common.response.ApiResponse;
 import com.example.dgbackend.global.jwt.dto.AuthRequest;
+import com.example.dgbackend.global.jwt.dto.AuthResponse;
 import com.example.dgbackend.global.jwt.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.io.IOException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Jwt Token", description = "로그아웃 및 토큰 재발행 API")
 @RestController
@@ -24,8 +28,8 @@ public class JwtController {
 
     @Operation(summary = "accessToken 재발급")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "accessToken 재발급 성공"),
-            @ApiResponse(responseCode = "403", description = "refreshToken이 만료되었습니다.")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "accessToken 재발급 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "refreshToken이 만료되었습니다.")
     })
     @GetMapping("/token")
     public ResponseEntity<?> refreshAccessToken(HttpServletRequest request) {
@@ -34,12 +38,14 @@ public class JwtController {
     }
 
     @PostMapping("/kakao")
-    public void kakaoLoign(@RequestBody AuthRequest authRequest, HttpServletResponse response) throws IOException {
-        authService.loginOrJoin(response, authRequest);
+    public ApiResponse<AuthResponse> kakaoLoign(@RequestBody AuthRequest authRequest,
+        HttpServletResponse response) throws IOException {
+        return ApiResponse.onSuccess(authService.loginOrJoin(response, authRequest));
     }
 
     @PostMapping("/naver")
-    public void naverLoign(@RequestBody AuthRequest authRequest, HttpServletResponse response) throws IOException {
-        authService.loginOrJoin(response, authRequest);
+    public ApiResponse<AuthResponse> naverLoign(@RequestBody AuthRequest authRequest,
+        HttpServletResponse response) throws IOException {
+        return ApiResponse.onSuccess(authService.loginOrJoin(response, authRequest));
     }
 }

--- a/src/main/java/com/example/dgbackend/global/jwt/dto/AuthResponse.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/dto/AuthResponse.java
@@ -1,0 +1,27 @@
+package com.example.dgbackend.global.jwt.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthResponse {
+
+    private String provider;
+    private String nickName;
+    private LocalDateTime createdAt;
+
+    public static AuthResponse toAuthResponse(String provider, String nickName) {
+
+        return AuthResponse.builder()
+            .provider(provider)
+            .nickName(nickName)
+            .createdAt(LocalDateTime.now())
+            .build();
+    }
+}

--- a/src/main/java/com/example/dgbackend/global/jwt/resolver/MemberArgumentResolver.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/resolver/MemberArgumentResolver.java
@@ -1,10 +1,10 @@
 package com.example.dgbackend.global.jwt.resolver;
 
 import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
+import com.example.dgbackend.global.exception.ApiException;
 import com.example.dgbackend.global.jwt.JwtProvider;
 import com.example.dgbackend.global.jwt.annotation.MemberObject;
-import com.example.dgbackend.global.jwt.service.AuthService;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -20,7 +20,9 @@ Header에 있는 토큰을 이용하여 유저 정보를 가져오는 클래스
 @Component
 @RequiredArgsConstructor
 public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
+
     private final JwtProvider jwtProvider;
+
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         boolean isUserIdAnnotation = parameter.getParameterAnnotation(MemberObject.class) != null;
@@ -30,10 +32,12 @@ public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         String token = webRequest.getHeader("Authorization");
-        if(token == null)
-            return null;
+        if (token == null) {
+            throw new ApiException(ErrorStatus._EMPTY_JWT);
+        }
 
         return jwtProvider.getMemberFromToken(token.split(" ")[1]);
     }

--- a/src/main/java/com/example/dgbackend/global/validation/annotation/CheckCombinationOwner.java
+++ b/src/main/java/com/example/dgbackend/global/validation/annotation/CheckCombinationOwner.java
@@ -1,0 +1,12 @@
+package com.example.dgbackend.global.validation.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckCombinationOwner {
+
+}

--- a/src/main/java/com/example/dgbackend/global/validation/annotation/CheckCombinationOwner.java
+++ b/src/main/java/com/example/dgbackend/global/validation/annotation/CheckCombinationOwner.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.PARAMETER)
+@Target({ElementType.PARAMETER, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CheckCombinationOwner {
 

--- a/src/main/java/com/example/dgbackend/global/validation/interceptor/CheckCombinationOwnerInterceptor.java
+++ b/src/main/java/com/example/dgbackend/global/validation/interceptor/CheckCombinationOwnerInterceptor.java
@@ -8,12 +8,14 @@ import com.example.dgbackend.global.jwt.JwtProvider;
 import com.example.dgbackend.global.validation.annotation.CheckCombinationOwner;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
 
 @Component
 @RequiredArgsConstructor
@@ -24,37 +26,34 @@ public class CheckCombinationOwnerInterceptor implements HandlerInterceptor {
     private final CombinationQueryService combinationQueryService;
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+        Object handler) throws Exception {
         // Handler가 메소드인 경우에만 진행
         if (handler instanceof HandlerMethod) {
             HandlerMethod handlerMethod = (HandlerMethod) handler;
 
-            // 핸들러 메소드의 매개변수를 가져와서 어노테이션이 있는지 확인
-            MethodParameter[] methodParameters = handlerMethod.getMethodParameters();
-            for (MethodParameter parameter : methodParameters) {
-                if (parameter.hasParameterAnnotation(CheckCombinationOwner.class)) {
-                    // JWT를 통해 로그인 사용자 정보 조회
-                    Member loginMember = getLoginMember(request);
+            // 핸들러 메서드에 @CheckCombinationOwner 어노테이션이 있는지 확인
+            if (handlerMethod.getMethod().isAnnotationPresent(CheckCombinationOwner.class)) {
+                // JWT를 통해 로그인 사용자 정보 조회
+                Member loginMember = getLoginMember(request);
 
-                    // URL에서 combinationId 추출
-                    Long combinationId = extractCombinationId(request);
+                // URL에서 combinationId 추출
+                Long combinationId = extractCombinationId(request);
 
-                    log.info("===================================CheckCombinationOwnerInterceptor combinationId = " + combinationId);
-                    // 로그인한 사용자가 작성자인지 확인
-                    if (loginMember != null) {
-                        Boolean isOwner = combinationQueryService.isCombinationOwner(combinationId, loginMember);
-                        if (!isOwner) {
-                            throw new ApiException(ErrorStatus._FORBIDDEN_MEMBER_REQUEST);
-                        }
-                    } else {
-                        throw new ApiException(ErrorStatus._UNAUTHORIZED);
+                // 로그인한 사용자가 작성자인지 확인
+                if (loginMember != null) {
+                    Boolean isOwner = combinationQueryService.isCombinationOwner(combinationId,
+                        loginMember);
+                    if (!isOwner) {
+                        throw new ApiException(ErrorStatus._FORBIDDEN_MEMBER_REQUEST);
                     }
+                } else {
+                    throw new ApiException(ErrorStatus._UNAUTHORIZED);
                 }
             }
         }
         return true;
     }
-
 
     private Member getLoginMember(HttpServletRequest request) {
         String token = jwtProvider.getJwtTokenFromHeader(request);
@@ -63,15 +62,13 @@ public class CheckCombinationOwnerInterceptor implements HandlerInterceptor {
     }
 
     private Long extractCombinationId(HttpServletRequest request) {
-
-        String requestURI = request.getRequestURI();
-        String[] uriParts = requestURI.split("/");
-        for (int i = 0; i < uriParts.length - 1; i++) {
-            if (uriParts[i].matches("\\d+")) {
-                return Long.parseLong(uriParts[i]);
-            }
-        }
-
-        throw new ApiException(ErrorStatus._UNAUTHORIZED);
+        return Optional.ofNullable(
+                request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
+            .map(Map.class::cast)
+            .map(map -> map.get("combinationId"))
+            .map(Object::toString)
+            .map(Long::parseLong)
+            .orElseThrow(() -> new ApiException(ErrorStatus._BAD_REQUEST));
     }
+
 }

--- a/src/main/java/com/example/dgbackend/global/validation/interceptor/CheckCombinationOwnerInterceptor.java
+++ b/src/main/java/com/example/dgbackend/global/validation/interceptor/CheckCombinationOwnerInterceptor.java
@@ -1,0 +1,77 @@
+package com.example.dgbackend.global.validation.interceptor;
+
+import com.example.dgbackend.domain.combination.service.CombinationQueryService;
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
+import com.example.dgbackend.global.exception.ApiException;
+import com.example.dgbackend.global.jwt.JwtProvider;
+import com.example.dgbackend.global.validation.annotation.CheckCombinationOwner;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CheckCombinationOwnerInterceptor implements HandlerInterceptor {
+
+    private final JwtProvider jwtProvider;
+    private final CombinationQueryService combinationQueryService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        // Handler가 메소드인 경우에만 진행
+        if (handler instanceof HandlerMethod) {
+            HandlerMethod handlerMethod = (HandlerMethod) handler;
+
+            // 핸들러 메소드의 매개변수를 가져와서 어노테이션이 있는지 확인
+            MethodParameter[] methodParameters = handlerMethod.getMethodParameters();
+            for (MethodParameter parameter : methodParameters) {
+                if (parameter.hasParameterAnnotation(CheckCombinationOwner.class)) {
+                    // JWT를 통해 로그인 사용자 정보 조회
+                    Member loginMember = getLoginMember(request);
+
+                    // URL에서 combinationId 추출
+                    Long combinationId = extractCombinationId(request);
+
+                    log.info("===================================CheckCombinationOwnerInterceptor combinationId = " + combinationId);
+                    // 로그인한 사용자가 작성자인지 확인
+                    if (loginMember != null) {
+                        Boolean isOwner = combinationQueryService.isCombinationOwner(combinationId, loginMember);
+                        if (!isOwner) {
+                            throw new ApiException(ErrorStatus._FORBIDDEN_MEMBER_REQUEST);
+                        }
+                    } else {
+                        throw new ApiException(ErrorStatus._UNAUTHORIZED);
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+
+    private Member getLoginMember(HttpServletRequest request) {
+        String token = jwtProvider.getJwtTokenFromHeader(request);
+
+        return jwtProvider.getMemberFromToken(token.split(" ")[1]);
+    }
+
+    private Long extractCombinationId(HttpServletRequest request) {
+
+        String requestURI = request.getRequestURI();
+        String[] uriParts = requestURI.split("/");
+        for (int i = 0; i < uriParts.length - 1; i++) {
+            if (uriParts[i].matches("\\d+")) {
+                return Long.parseLong(uriParts[i]);
+            }
+        }
+
+        throw new ApiException(ErrorStatus._UNAUTHORIZED);
+    }
+}


### PR DESCRIPTION
## 요약

- 오늘의 조합 API에서 로그인 사용자 정보가 필요한 부분을 수정하였습니다.
- @MemberObject를 적용하여 로그인 사용자 정보가 필요한 API에 적용하였습니다.
- 기존의 Hard Delete 방식에서 Soft Delete 방식으로 변경하였습니다.
- HandlerInterceptor를 구현하여 작성자가 아닌 사용자의 수정, 수정조회, 삭제 권한을 제한하였습니다.

## 상세 내용

1. 오늘의 조합 홈 API
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/dcd0beb6-229a-403d-8f3a-2ef12916170c)

2. 오늘의 조합 상세보기 API
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/45f46d06-9a30-4d76-9ff1-f58b6c75be7b)

3. 오늘의 조합 수정 페이지 조회 API
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/ad354216-3eb0-455d-987e-38f2876a9765)

4. 오늘의 조합 수정 API
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/f3cd6420-7e03-4d4c-937d-8f74227cb779)

5. 오늘의 조합 삭제 API
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/5c613994-e230-4b0c-8b1f-7b95f2bd4062)


## 질문 및 이외 사항

-

## 이슈 번호

- close #101 