### PR TITLE
FIX: 오늘의 조합 댓글 관련 API 및 로그인 사용자 정보 적용

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
@@ -26,4 +26,6 @@ public interface CombinationRepository extends JpaRepository<Combination, Long> 
     Page<Combination> findCombinationsByTitleContainingAndLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
         String keyword, PageRequest pageRequest, Long likeCount);
 
+    boolean existsByIdAndState(Long combinationId, boolean state);
+
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryService.java
@@ -15,7 +15,7 @@ public interface CombinationQueryService {
 
     CombinationEditResult getCombinationEditResult(Long combinationId);
 
-    boolean existCombination(Long combinationId);
+    boolean existCombination(Long combinationId, boolean state);
 
     Combination getCombination(Long combinationId);
 

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -105,8 +105,8 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
     }
 
     @Override
-    public boolean existCombination(Long combinationId) {
-        return combinationRepository.existsById(combinationId);
+    public boolean existCombination(Long combinationId, boolean state) {
+        return combinationRepository.existsByIdAndState(combinationId, state);
     }
 
     /*

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/controller/CombinationCommentController.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/controller/CombinationCommentController.java
@@ -92,7 +92,7 @@ public class CombinationCommentController {
     })
     @Parameter(name = "commentId", description = "수정하는 댓글 Id, Path Variable 입니다.")
     @PatchMapping("/{commentId}")
-    public ApiResponse<CombinationCommentResponse.CommentProcResult> updateCombinationComment(
+    public ApiResponse<CombinationCommentResponse.CommentResult> updateCombinationComment(
         @PathVariable(name = "commentId") Long commentId,
         @RequestBody CombinationCommentRequest.UpdateComment request) {
 

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/controller/CombinationCommentController.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/controller/CombinationCommentController.java
@@ -93,7 +93,7 @@ public class CombinationCommentController {
     @Parameter(name = "commentId", description = "수정하는 댓글 Id, Path Variable 입니다.")
     @PatchMapping("/{commentId}")
     public ApiResponse<CombinationCommentResponse.CommentProcResult> updateCombinationComment(
-        @ExistCombination @PathVariable(name = "commentId") Long commentId,
+        @PathVariable(name = "commentId") Long commentId,
         @RequestBody CombinationCommentRequest.UpdateComment request) {
 
         return ApiResponse.onSuccess(

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/controller/CombinationCommentController.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/controller/CombinationCommentController.java
@@ -1,11 +1,15 @@
 package com.example.dgbackend.domain.combinationcomment.controller;
 
 
+import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentPreViewResult;
+
 import com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentRequest;
 import com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse;
 import com.example.dgbackend.domain.combinationcomment.service.CombinationCommentCommandService;
 import com.example.dgbackend.domain.combinationcomment.service.CombinationCommentQueryService;
+import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.global.common.response.ApiResponse;
+import com.example.dgbackend.global.jwt.annotation.MemberObject;
 import com.example.dgbackend.global.validation.annotation.CheckPage;
 import com.example.dgbackend.global.validation.annotation.ExistCombination;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,9 +19,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
-
-import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentPreViewResult;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 
 @Tag(name = "오늘의 조합 댓글 관련 API")
@@ -32,53 +42,61 @@ public class CombinationCommentController {
 
     @Operation(summary = "특정 오늘의 조합의 댓글 페이징 조회 ", description = "특정 오늘의 조합의 댓글을 조회합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 댓글 작성 성공")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 댓글 작성 성공")
     })
     @Parameters({
-            @Parameter(name = "combinationId", description = "댓글을 작성하는 오늘의 조합 Id, Path Variable 입니다."),
-            @Parameter(name = "page", description = "특정 오늘의 조합의  댓글 목록 페이지 번호, query string 입니다.")
+        @Parameter(name = "combinationId", description = "댓글을 작성하는 오늘의 조합 Id, Path Variable 입니다."),
+        @Parameter(name = "page", description = "특정 오늘의 조합의  댓글 목록 페이지 번호, query string 입니다.")
     })
     @GetMapping("/{combinationId}")
-    public ApiResponse<CommentPreViewResult> getCombinationComments(@ExistCombination @PathVariable(name = "combinationId") Long combinationId,
-                                                                    @CheckPage @RequestParam(name = "page") Integer page) {
+    public ApiResponse<CommentPreViewResult> getCombinationComments(
+        @ExistCombination @PathVariable(name = "combinationId") Long combinationId,
+        @CheckPage @RequestParam(name = "page") Integer page) {
 
-        return ApiResponse.onSuccess(combinationCommentQueryService.getCommentsFromCombination(combinationId, page));
+        return ApiResponse.onSuccess(
+            combinationCommentQueryService.getCommentsFromCombination(combinationId, page));
     }
 
     @Operation(summary = "오늘의 조합 댓글 작성", description = "오늘의 조합에 댓글을 작성합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 댓글 작성 성공")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 댓글 작성 성공")
     })
     @Parameter(name = "combinationId", description = "작성하는 오늘의 조합 Id, Path Variable 입니다.")
     @PostMapping("/{combinationId}")
-    public ApiResponse<CombinationCommentResponse.CommentResult> saveCombinationComment(@PathVariable(name = "combinationId") Long combinationId,
-                                                                                        @RequestBody CombinationCommentRequest.WriteComment request) {
+    public ApiResponse<CombinationCommentResponse.CommentResult> saveCombinationComment(
+        @Parameter(hidden = true) @MemberObject Member loginMember,
+        @ExistCombination @PathVariable(name = "combinationId") Long combinationId,
+        @RequestBody CombinationCommentRequest.WriteComment request) {
 
-        // TODO: HttpServletRequest 사용해서 Authorization token으로 사용자 정보 받아오기
-        return ApiResponse.onSuccess(combinationCommentCommandService.saveCombinationComment(combinationId, request));
+        return ApiResponse.onSuccess(
+            combinationCommentCommandService.saveCombinationComment(loginMember, combinationId,
+                request));
     }
 
 
     @Operation(summary = "오늘의 조합 댓글 삭제", description = "오늘의 조합에 댓글을 삭제합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 댓글 삭제 성공")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 댓글 삭제 성공")
     })
     @Parameter(name = "commentId", description = "작성된 댓글 Id, Path Variable 입니다.")
     @DeleteMapping("/{commentId}")
-    public ApiResponse<CombinationCommentResponse.CommentProcResult> deleteCombinationComment(@PathVariable(name = "commentId") Long commentId) {
+    public ApiResponse<CombinationCommentResponse.CommentProcResult> deleteCombinationComment(
+        @PathVariable(name = "commentId") Long commentId) {
 
         return ApiResponse.onSuccess(combinationCommentCommandService.deleteComment(commentId));
     }
-      
+
     @Operation(summary = "오늘의 조합 댓글 수정", description = "오늘의 조합의 댓글을 수정합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 댓글 수정 성공")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 댓글 수정 성공")
     })
     @Parameter(name = "commentId", description = "수정하는 댓글 Id, Path Variable 입니다.")
     @PatchMapping("/{commentId}")
-    public ApiResponse<CombinationCommentResponse.CommentProcResult> updateCombinationComment(@PathVariable(name = "commentId") Long commentId,
-                                                                                              @RequestBody CombinationCommentRequest.UpdateComment request) {
+    public ApiResponse<CombinationCommentResponse.CommentProcResult> updateCombinationComment(
+        @ExistCombination @PathVariable(name = "commentId") Long commentId,
+        @RequestBody CombinationCommentRequest.UpdateComment request) {
 
-        return ApiResponse.onSuccess(combinationCommentCommandService.updateComment(commentId, request));
+        return ApiResponse.onSuccess(
+            combinationCommentCommandService.updateComment(commentId, request));
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/dto/CombinationCommentResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/dto/CombinationCommentResponse.java
@@ -1,6 +1,7 @@
 package com.example.dgbackend.domain.combinationcomment.dto;
 
 import com.example.dgbackend.domain.combinationcomment.CombinationComment;
+import com.example.dgbackend.global.util.DateTimeUtils;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -59,7 +60,7 @@ public class CombinationCommentResponse {
         private Long id;
         private String content;
         private String memberName;
-        private LocalDateTime updatedAt; // 댓글 생성 및 수정 시간
+        private String updatedAt; // 댓글 생성 및 수정 시간
         private Integer childCount;
         private List<CommentResult> childComments = new ArrayList<>();
     }
@@ -70,7 +71,7 @@ public class CombinationCommentResponse {
                 .id(combinationComment.getId())
                 .content(combinationComment.getContent())
                 .memberName(combinationComment.getMember().getName())
-                .updatedAt(combinationComment.getUpdatedAt())
+                .updatedAt(DateTimeUtils.formatLocalDateTime(combinationComment.getUpdatedAt()))
                 .childCount(getChildCount(combinationComment))
                 .childComments(getChildComments(combinationComment))
                 .build();

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentCommandService.java
@@ -14,10 +14,6 @@ public interface CombinationCommentCommandService {
     CombinationComment createComment(Combination combination, Member member,
         CombinationCommentRequest.WriteComment request);
 
-    CombinationComment getParentComment(Long parentId);
-
-    CombinationComment getComment(Long commentId);
-
     CombinationCommentResponse.CommentProcResult deleteComment(Long commentId);
 
     CombinationCommentResponse.CommentProcResult updateComment(Long commentId,

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentCommandService.java
@@ -8,9 +8,11 @@ import com.example.dgbackend.domain.member.Member;
 
 public interface CombinationCommentCommandService {
 
-    CombinationCommentResponse.CommentResult saveCombinationComment(Long combinationId, CombinationCommentRequest.WriteComment request);
+    CombinationCommentResponse.CommentResult saveCombinationComment(Member loginMember,
+        Long combinationId, CombinationCommentRequest.WriteComment request);
 
-    CombinationComment createComment(Combination combination, Member member, CombinationCommentRequest.WriteComment request);
+    CombinationComment createComment(Combination combination, Member member,
+        CombinationCommentRequest.WriteComment request);
 
     CombinationComment getParentComment(Long parentId);
 
@@ -18,7 +20,8 @@ public interface CombinationCommentCommandService {
 
     CombinationCommentResponse.CommentProcResult deleteComment(Long commentId);
 
-    CombinationCommentResponse.CommentProcResult updateComment(Long commentId, CombinationCommentRequest.UpdateComment request);
+    CombinationCommentResponse.CommentProcResult updateComment(Long commentId,
+        CombinationCommentRequest.UpdateComment request);
 
     boolean deleteAllComment(Long memberId);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentCommandService.java
@@ -16,7 +16,7 @@ public interface CombinationCommentCommandService {
 
     CombinationCommentResponse.CommentProcResult deleteComment(Long commentId);
 
-    CombinationCommentResponse.CommentProcResult updateComment(Long commentId,
+    CombinationCommentResponse.CommentResult updateComment(Long commentId,
         CombinationCommentRequest.UpdateComment request);
 
     boolean deleteAllComment(Long memberId);

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentCommandServiceImpl.java
@@ -71,7 +71,7 @@ public class CombinationCommentCommandServiceImpl implements CombinationCommentC
     }
 
     @Override
-    public CombinationCommentResponse.CommentProcResult updateComment(Long commentId,
+    public CombinationCommentResponse.CommentResult updateComment(Long commentId,
         CombinationCommentRequest.UpdateComment request) {
 
         CombinationComment combinationComment = combinationCommentQueryService.getComment(
@@ -79,7 +79,7 @@ public class CombinationCommentCommandServiceImpl implements CombinationCommentC
 
         combinationComment.updateComment(request.getContent());
 
-        return toCommentProcResult(commentId);
+        return toCommentResult(combinationComment);
     }
 
     @Override

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentQueryService.java
@@ -2,7 +2,15 @@ package com.example.dgbackend.domain.combinationcomment.service;
 
 import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentPreViewResult;
 
+import com.example.dgbackend.domain.combinationcomment.CombinationComment;
+
 public interface CombinationCommentQueryService {
 
     CommentPreViewResult getCommentsFromCombination(Long combinationId, Integer page);
+
+    CombinationComment getParentComment(Long parentId);
+
+    CombinationComment getComment(Long commentId);
+
+    CombinationComment isDelete(CombinationComment comment);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentQueryServiceImpl.java
@@ -1,13 +1,16 @@
 package com.example.dgbackend.domain.combinationcomment.service;
 
+import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentPreViewResult;
+import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.toCommentPreViewResult;
+
+import com.example.dgbackend.domain.combinationcomment.CombinationComment;
 import com.example.dgbackend.domain.combinationcomment.repository.CombinationCommentRepository;
+import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
+import com.example.dgbackend.global.exception.ApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentPreViewResult;
-import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.toCommentPreViewResult;
 
 @Service
 @Transactional(readOnly = true)
@@ -19,6 +22,38 @@ public class CombinationCommentQueryServiceImpl implements CombinationCommentQue
     @Override
     public CommentPreViewResult getCommentsFromCombination(Long combinationId, Integer page) {
 
-        return toCommentPreViewResult(combinationCommentRepository.findAllByCombinationId(combinationId, PageRequest.of(page, 10)));
+        return toCommentPreViewResult(
+            combinationCommentRepository.findAllByCombinationId(combinationId,
+                PageRequest.of(page, 10)));
+    }
+
+    @Override
+    public CombinationComment getParentComment(Long parentId) {
+        CombinationComment parentComment = getComment(parentId);
+
+        // 부모의 부모 댓글이 존재할 경우 => 에러 핸들러 실행 (대댓글까지 가능)
+        if (parentComment.getParentComment() != null) {
+            throw new ApiException(ErrorStatus._OVER_DEPTH_COMBINATION_COMMENT);
+        }
+        return parentComment;
+    }
+
+    @Override
+    public CombinationComment getComment(Long commentId) {
+        CombinationComment comment = combinationCommentRepository.findById(commentId)
+            .orElseThrow(
+                () -> new ApiException(ErrorStatus._COMBINATION_COMMENT_NOT_FOUND)
+            );
+        return isDelete(comment);
+
+    }
+
+    @Override
+    public CombinationComment isDelete(CombinationComment comment) {
+
+        if (!comment.isState()) {
+            throw new ApiException(ErrorStatus._DELETE_COMBINATION_COMMENT);
+        }
+        return comment;
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationimage/controller/CombinationImageController.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationimage/controller/CombinationImageController.java
@@ -6,17 +6,17 @@ import com.example.dgbackend.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.util.List;
-
-@Tag(name = "오늘의 조합 API")
+@Tag(name = "오늘의 조합 이미지 API")
 @RestController
 @RequestMapping("/combinationImages")
 @RequiredArgsConstructor
@@ -26,10 +26,12 @@ public class CombinationImageController {
 
     @Operation(summary = "오늘의 조합 이미지 업로드", description = "오늘의 조합 이미지를 업로드합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 이미지 업로드 성공")
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 이미지 업로드 성공")
     })
-    @PostMapping("")
-    public ApiResponse<CombinationImageResponse.CombinationImageResult> imageUpload(@RequestPart(name = "imageUrls", required = false) List<MultipartFile> multipartFiles) throws IOException {
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<CombinationImageResponse.CombinationImageResult> imageUpload(
+        @RequestPart(name = "imageUrls", required = false) List<MultipartFile> multipartFiles)
+        throws IOException {
         return ApiResponse.onSuccess(combinationImageCommandService.uploadImage(multipartFiles));
 
     }

--- a/src/main/java/com/example/dgbackend/domain/combinationimage/service/CombinationImageCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationimage/service/CombinationImageCommandServiceImpl.java
@@ -4,14 +4,15 @@ import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.combinationimage.CombinationImage;
 import com.example.dgbackend.domain.combinationimage.dto.CombinationImageResponse;
 import com.example.dgbackend.domain.combinationimage.repository.CombinationImageRepository;
+import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
+import com.example.dgbackend.global.exception.ApiException;
 import com.example.dgbackend.global.s3.S3Service;
 import com.example.dgbackend.global.s3.dto.S3Result;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -22,25 +23,38 @@ public class CombinationImageCommandServiceImpl implements CombinationImageComma
     private final S3Service s3Service;
 
     @Override
-    public CombinationImageResponse.CombinationImageResult uploadImage(List<MultipartFile> multipartFiles) {
+    public CombinationImageResponse.CombinationImageResult uploadImage(
+        List<MultipartFile> requestFiles) {
+
+        List<MultipartFile> multipartFiles = validFileList(requestFiles);
 
         // S3에 이미지 업로드
         List<String> imageUrls = s3Service.uploadFile(multipartFiles)
-                .stream()
-                .map(S3Result::getImgUrl)
-                .toList();
+            .stream()
+            .map(S3Result::getImgUrl)
+            .toList();
 
         return CombinationImageResponse.toCombinationImageResult(imageUrls);
+    }
+
+    private List<MultipartFile> validFileList(List<MultipartFile> request) {
+
+        if (request == null || request.isEmpty()) {
+            throw new ApiException(ErrorStatus._COMBINATION_IMAGE_NOT_FOUND);
+        }
+
+        return request;
     }
 
     @Override
     public void updateCombinationImage(Combination combination, List<String> combinationImageList) {
 
         // 0. 기존의 이미지 파일 조회
-        List<String> existCombinationImageUrls = combinationImageRepository.findAllByCombinationId(combination.getId())
-                .stream()
-                .map(CombinationImage::getImageUrl)
-                .toList();
+        List<String> existCombinationImageUrls = combinationImageRepository.findAllByCombinationId(
+                combination.getId())
+            .stream()
+            .map(CombinationImage::getImageUrl)
+            .toList();
 
         // 2. 수정하면서 없어진 이미지를 S3에서 삭제하기
         removeCancelledCombinationImage(combinationImageList, existCombinationImageUrls);
@@ -50,30 +64,30 @@ public class CombinationImageCommandServiceImpl implements CombinationImageComma
     }
 
     private void removeCancelledCombinationImage(List<String> combinationImageList,
-                                                 List<String> existCombinationImageUrls) {
+        List<String> existCombinationImageUrls) {
 
         List<String> delImageUrls = existCombinationImageUrls.stream()
-                .filter(existImage -> !combinationImageList.contains(existImage))
-                .toList();
+            .filter(existImage -> !combinationImageList.contains(existImage))
+            .toList();
 
         delImageUrls.forEach(s3Service::deleteFile);
         delImageUrls.forEach(combinationImageRepository::deleteByImageUrl);
     }
 
     private void addNewCombinationImage(Combination combination,
-                                        List<String> combinationImageList,
-                                        List<String> existCombinationImageUrls) {
+        List<String> combinationImageList,
+        List<String> existCombinationImageUrls) {
 
         List<String> addImageUrls = combinationImageList.stream()
-                .filter(request -> !existCombinationImageUrls.contains(request))
-                .toList();
+            .filter(request -> !existCombinationImageUrls.contains(request))
+            .toList();
 
         List<CombinationImage> combinationImages = addImageUrls.stream()
-                .map(image -> CombinationImage.builder()
-                        .combination(combination)
-                        .imageUrl(image)
-                        .build())
-                .toList();
+            .map(image -> CombinationImage.builder()
+                .combination(combination)
+                .imageUrl(image)
+                .build())
+            .toList();
 
         combinationImages.forEach(combination::addCombinationImage);
     }

--- a/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
@@ -24,6 +24,7 @@ public enum ErrorStatus implements BaseErrorCode {
     //오늘의 조합 댓글
     _COMBINATION_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMBINATION_COMMENT_001", "존재하지 않는 오늘의 조합 댓글입니다."),
     _OVER_DEPTH_COMBINATION_COMMENT(HttpStatus.BAD_REQUEST, "COMBINATION_COMMENT_002", "대댓글까지만 가능합니다."),
+    _DELETE_COMBINATION_COMMENT(HttpStatus.BAD_REQUEST, "COMBINATION_COMMENT_003", "이미 삭제된 오늘의 조합 댓글입니다."),
 
     //Recommend 관련
     _RECOMMEND_NOT_FOUND(HttpStatus.NOT_FOUND, "RECOMMEND_001", "존재하지 않는 추천 조합입니다."),

--- a/src/main/java/com/example/dgbackend/global/util/DateTimeUtils.java
+++ b/src/main/java/com/example/dgbackend/global/util/DateTimeUtils.java
@@ -1,0 +1,15 @@
+package com.example.dgbackend.global.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DateTimeUtils {
+
+    public static String formatLocalDateTime(LocalDateTime dateTime) {
+        return dateTime.format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm"));
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/global/validation/validator/CombinationExistValidator.java
+++ b/src/main/java/com/example/dgbackend/global/validation/validator/CombinationExistValidator.java
@@ -22,7 +22,7 @@ public class CombinationExistValidator implements ConstraintValidator<ExistCombi
     @Override
     public boolean isValid(Long combinationId, ConstraintValidatorContext context) {
 
-        boolean valid = combinationQueryService.existCombination(combinationId);
+        boolean valid = combinationQueryService.existCombination(combinationId, true);
 
         if (!valid) {
             context.disableDefaultConstraintViolation();


### PR DESCRIPTION
## 요약

- 로그인 사용자 정보를 적용하여,  사용자 정보가 필요한 API에 기능을 추가합니다.
- 오늘의 조합 댓글 부분의 API를 최종 검토합니다.

## 상세 내용

1. 오늘의 조합 댓글 조회 API
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/eb5ad0c5-7938-4c3b-94de-feb49a212b5b)

2. 오늘의 조합 댓글 작성 API
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/158de434-7dfe-44e2-ac7d-f885fb48ab22)

3. 오늘의 조합 댓글 수정 API
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/c38778b6-e947-4ccf-a40b-ea6851afa8d8)

4. 오늘의 조합 댓글 삭제 API
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/92b66b14-0d19-46c6-8702-10d38fa70116)


## 질문 및 이외 사항

- 105번 이슈에 마지막 2개의 커밋이 잘못 Related 되어 있습니다.
- 실제 적용은 fix/combination 브랜치에 적용되어 있고, fix/combination-comment에는 적용되어 있지 않습니다.

## 이슈 번호

- close #105 