### PR TITLE
fix: 소셜 로그인 처리 후 Refresh Toekn 전달 방법 수정

### DIFF
--- a/src/main/java/com/example/dgbackend/global/jwt/controller/JwtController.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/controller/JwtController.java
@@ -12,7 +12,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,7 +30,7 @@ public class JwtController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "accessToken 재발급 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "refreshToken이 만료되었습니다.")
     })
-    @GetMapping("/token")
+    @PostMapping("/reissue-token")
     public ResponseEntity<?> refreshAccessToken(HttpServletRequest request) {
 
         return authService.reIssueAccessToken(request);

--- a/src/main/java/com/example/dgbackend/global/jwt/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/handler/CustomLogoutHandler.java
@@ -25,7 +25,7 @@ public class CustomLogoutHandler implements LogoutSuccessHandler {
         authService.logout(request, response);
 
         // 로그아웃 후 리다이렉션
-        String redirectUrl = "/login";
+        String redirectUrl = "/";
         response.sendRedirect(redirectUrl);
     }
 


### PR DESCRIPTION
## 요약

- 회원가입 및 로그인 처리 후 Refresh Token 전달 방법 수정

## 상세 내용

- 회원가입 및 로그인 처리 후 Refresh Token을 Header에 담아 전달합니다.
- 로그아웃 시 Cookie가 아닌 Header에 RefreshToken을 삭제

**1. 회원가입 및 로그인 실행결과**
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/f23c404c-bde5-4c32-81fb-2ba6380b2cf0)

**2. 로그아웃 실행결과**

> Redirect Url을 "/"로 설정했는데 프론트와 상의 후 수정
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/9b4874f0-1cfe-4da3-85df-8b732f9d75f8)

**3. Access Token 재발급 실행결과**
![image](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/103489352/29c29cc7-226b-4207-86cc-31eee5373402)

## 질문 및 이외 사항

## 이슈 번호

- close #109 