### PR TITLE
Feature : 레시피북 해시태그 추가

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/hashtag/service/HashTagCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/hashtag/service/HashTagCommandService.java
@@ -1,10 +1,13 @@
 package com.example.dgbackend.domain.hashtag.service;
 
 import com.example.dgbackend.domain.combination.Combination;
+import com.example.dgbackend.domain.hashtag.HashTag;
 
 import java.util.List;
 
 public interface HashTagCommandService {
 
     void uploadHashTag(Combination combination, List<String> hashTageNames);
+
+    List<HashTag> getHashTags(List<String> hashTageNames);
 }

--- a/src/main/java/com/example/dgbackend/domain/hashtag/service/HashTagCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/hashtag/service/HashTagCommandServiceImpl.java
@@ -12,6 +12,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.stream.Collectors.toList;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -23,9 +25,7 @@ public class HashTagCommandServiceImpl implements HashTagCommandService {
     @Override
     public void uploadHashTag(Combination combination, List<String> hashTageNames) {
 
-        List<HashTag> hashTags = hashTageNames.stream()
-                .map(this::getOrCreateHashTag)
-                .toList();
+        List<HashTag> hashTags = getHashTags(hashTageNames);
 
         hashTags.forEach(hashTag -> {
             HashTagOption hashTagOption = HashTagOption.builder()
@@ -33,9 +33,20 @@ public class HashTagCommandServiceImpl implements HashTagCommandService {
                     .combination(combination)
                     .build();
 
-            hashTagRepository.save(hashTag);
             hashTagOptionRepository.save(hashTagOption);
         });
+    }
+
+    @Override
+    public List<HashTag> getHashTags(List<String> hashTageNames) {
+
+        List<HashTag> hashTags = hashTageNames.stream()
+                .map(ht->{
+                    return hashTagRepository.save(getOrCreateHashTag(ht));
+                })
+                .toList();
+
+        return hashTags;
     }
 
     private HashTag getOrCreateHashTag(String hashTagName) {

--- a/src/main/java/com/example/dgbackend/domain/recipe/Recipe.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/Recipe.java
@@ -10,7 +10,9 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Getter
 @AllArgsConstructor
@@ -56,12 +58,13 @@ public class Recipe extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Builder.Default
     @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL)
     private List<RecipeImage> recipeImageList = new ArrayList<>();
 
     @Builder.Default
     @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL)
-    private List<RecipeHashTag> recipeHashTagList = new ArrayList<>();
+    private Set<RecipeHashTag> recipeHashTagList = new HashSet<>();
 
     public Recipe update(RecipeRequest recipeResponseDto) {
         this.name = recipeResponseDto.getName();
@@ -98,4 +101,9 @@ public class Recipe extends BaseTimeEntity {
         }
 
     }
+
+    public void setHashTagList(List<RecipeHashTag> recipeHashTagList) {
+        this.recipeHashTagList.addAll(recipeHashTagList);
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe/Recipe.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/Recipe.java
@@ -103,7 +103,7 @@ public class Recipe extends BaseTimeEntity {
     }
 
     public void setHashTagList(List<RecipeHashTag> recipeHashTagList) {
-        this.recipeHashTagList.addAll(recipeHashTagList);
+        this.recipeHashTagList = new HashSet<>(recipeHashTagList);
     }
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe/Recipe.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/Recipe.java
@@ -2,6 +2,7 @@ package com.example.dgbackend.domain.recipe;
 
 import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.recipe.dto.RecipeRequest;
+import com.example.dgbackend.domain.recipe_hashtag.RecipeHashTag;
 import com.example.dgbackend.domain.recipeimage.RecipeImage;
 import com.example.dgbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -57,6 +58,10 @@ public class Recipe extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL)
     private List<RecipeImage> recipeImageList = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL)
+    private List<RecipeHashTag> recipeHashTagList = new ArrayList<>();
 
     public Recipe update(RecipeRequest recipeResponseDto) {
         this.name = recipeResponseDto.getName();

--- a/src/main/java/com/example/dgbackend/domain/recipe/dto/RecipeRequest.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/dto/RecipeRequest.java
@@ -9,6 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -41,6 +43,9 @@ public class RecipeRequest {
 
     @Schema(description = "추천 조합", example = "김치찌개와 참이슬")
     private String recommendCombination;
+
+    @Schema(description = "해시태그 리스트", example = "[김치찌개, 참이슬]")
+    private List<String> hashTagNameList;
 
     public static Recipe toEntity(RecipeRequest recipeRequest, Member member) {
         return Recipe.builder()

--- a/src/main/java/com/example/dgbackend/domain/recipe/dto/RecipeResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/dto/RecipeResponse.java
@@ -1,6 +1,7 @@
 package com.example.dgbackend.domain.recipe.dto;
 
 import com.example.dgbackend.domain.recipe.Recipe;
+import com.example.dgbackend.domain.recipe_hashtag.dto.RecipeHashTagResponse;
 import com.example.dgbackend.domain.recipeimage.RecipeImage;
 import com.example.dgbackend.domain.recipeimage.dto.RecipeImageResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -116,6 +117,7 @@ public class RecipeResponse {
                 .state(recipe.isState())
                 .memberNickName(recipe.getMember().getNickName())
                 .recipeImageList(RecipeImageResponse.toStringResponse(recipe.getRecipeImageList()))
+                .hashTagNameList(RecipeHashTagResponse.toStringResponse(recipe.getRecipeHashTagList()))
                 .build();
     }
 

--- a/src/main/java/com/example/dgbackend/domain/recipe/dto/RecipeResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/dto/RecipeResponse.java
@@ -68,6 +68,9 @@ public class RecipeResponse {
     @Schema(description = "레시피 이미지 목록")
     private List<String> recipeImageList;
 
+    @Schema(description = "해시태그 리스트", example = "[김치찌개, 참이슬]")
+    private List<String> hashTagNameList;
+
 
     @Builder
     @Getter

--- a/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
@@ -79,6 +79,7 @@ public class RecipeServiceImpl implements RecipeService {
     @Transactional
     public void deleteRecipe(Long id) {
         getRecipe(id).delete();
+        recipeHashTagService.deleteRecipeHashTag(id);
     }
 
     //레시피 이름과 회원 이름으로 레시피 탐색

--- a/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
@@ -6,18 +6,16 @@ import com.example.dgbackend.domain.recipe.Recipe;
 import com.example.dgbackend.domain.recipe.dto.RecipeRequest;
 import com.example.dgbackend.domain.recipe.dto.RecipeResponse;
 import com.example.dgbackend.domain.recipe.repository.RecipeRepository;
+import com.example.dgbackend.domain.recipe_hashtag.RecipeHashTag;
+import com.example.dgbackend.domain.recipe_hashtag.service.RecipeHashTagService;
 import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
 import com.example.dgbackend.global.exception.ApiException;
 import jakarta.transaction.Transactional;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -32,6 +30,7 @@ public class RecipeServiceImpl implements RecipeService {
 
     private final RecipeRepository recipeRepository;
     private final MemberService memberService;
+    private final RecipeHashTagService recipeHashTagService;
 
     @Override
     public RecipeResponse.RecipeResponseList getExistRecipes(int page) {
@@ -47,12 +46,22 @@ public class RecipeServiceImpl implements RecipeService {
     }
 
     @Override
+    @Transactional
     public RecipeResponse createRecipe(RecipeRequest recipeRequest, Member member) {
 
         Member memberEntity = memberService.findMemberByName(member.getName());
         isAlreadyCreate(recipeRequest.getName(), memberEntity.getName());
-        return RecipeResponse.toResponse(
-            recipeRepository.save(RecipeRequest.toEntity(recipeRequest, memberEntity)));
+
+        //레시피 저장
+        Recipe save = recipeRepository.save(RecipeRequest.toEntity(recipeRequest, memberEntity));
+
+        //해시태그 저장
+        List<RecipeHashTag> hashTags = recipeHashTagService.uploadRecipeHashTag(save, recipeRequest.getHashTagNameList());
+
+        //레시피에 해시태그 저장
+        save.setHashTagList(hashTags);
+
+        return RecipeResponse.toResponse(save);
     }
 
     @Override
@@ -74,7 +83,7 @@ public class RecipeServiceImpl implements RecipeService {
     public Recipe getRecipe(Long id) {
 
         Recipe recipe = recipeRepository.findById(id)
-            .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE));
+                .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE));
 
         return isDelete(recipe);
     }
@@ -93,18 +102,18 @@ public class RecipeServiceImpl implements RecipeService {
     @Override
     public void isAlreadyCreate(String RecipeName, String memberName) {
         recipeRepository.findAllByNameAndMember_Name(RecipeName, memberName).stream()
-            .filter(Recipe::isState)
-            .findFirst()
-            .ifPresent(recipe -> {
-                throw new ApiException(ErrorStatus._ALREADY_CREATE_RECIPE);
-            });
+                .filter(Recipe::isState)
+                .findFirst()
+                .ifPresent(recipe -> {
+                    throw new ApiException(ErrorStatus._ALREADY_CREATE_RECIPE);
+                });
     }
 
     @Override
     public List<RecipeResponse> findRecipesByKeyword(Integer page, String keyword) {
         return recipeRepository.findRecipesByNameContaining(keyword).stream()
-            .map(RecipeResponse::toResponse)
-            .toList();
+                .map(RecipeResponse::toResponse)
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
@@ -68,7 +68,10 @@ public class RecipeServiceImpl implements RecipeService {
     @Transactional
     public RecipeResponse updateRecipe(Long id, RecipeRequest recipeRequest) {
         Recipe recipe = getRecipe(id);
-        isAlreadyCreate(recipeRequest.getName(), recipe.getMember().getName());
+
+        //해시태그 저장
+        List<RecipeHashTag> hashTags = recipeHashTagService.uploadRecipeHashTag(recipe, recipeRequest.getHashTagNameList());
+        recipe.setHashTagList(hashTags);
         return RecipeResponse.toResponse(recipe.update(recipeRequest));
     }
 

--- a/src/main/java/com/example/dgbackend/domain/recipe_hashtag/RecipeHashTag.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe_hashtag/RecipeHashTag.java
@@ -1,0 +1,30 @@
+package com.example.dgbackend.domain.recipe_hashtag;
+
+import com.example.dgbackend.domain.hashtag.HashTag;
+import com.example.dgbackend.domain.recipe.Recipe;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class RecipeHashTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipe_id")
+    private Recipe recipe;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hashtag_id")
+    private HashTag hashtag;
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipe_hashtag/dto/RecipeHashTagResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe_hashtag/dto/RecipeHashTagResponse.java
@@ -1,0 +1,17 @@
+package com.example.dgbackend.domain.recipe_hashtag.dto;
+
+import com.example.dgbackend.domain.recipe_hashtag.RecipeHashTag;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+public class RecipeHashTagResponse {
+    public static List<String> toStringResponse(Set<RecipeHashTag> hashTagNameList) {
+        return hashTagNameList.stream()
+                .map(hashTag -> hashTag.getHashtag().getName())
+                .toList();
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipe_hashtag/repository/RecipeHashTagRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe_hashtag/repository/RecipeHashTagRepository.java
@@ -1,7 +1,13 @@
 package com.example.dgbackend.domain.recipe_hashtag.repository;
 
+import com.example.dgbackend.domain.hashtag.HashTag;
 import com.example.dgbackend.domain.recipe_hashtag.RecipeHashTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RecipeHashTagRepository extends JpaRepository<RecipeHashTag, Long> {
+
+    Optional<RecipeHashTag> findByRecipe_IdAndHashtag_Id(Long recipeId, Long hashtagId);
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe_hashtag/repository/RecipeHashTagRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe_hashtag/repository/RecipeHashTagRepository.java
@@ -1,0 +1,7 @@
+package com.example.dgbackend.domain.recipe_hashtag.repository;
+
+import com.example.dgbackend.domain.recipe_hashtag.RecipeHashTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecipeHashTagRepository extends JpaRepository<RecipeHashTag, Long> {
+}

--- a/src/main/java/com/example/dgbackend/domain/recipe_hashtag/repository/RecipeHashTagRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe_hashtag/repository/RecipeHashTagRepository.java
@@ -10,4 +10,6 @@ public interface RecipeHashTagRepository extends JpaRepository<RecipeHashTag, Lo
 
     Optional<RecipeHashTag> findByRecipe_IdAndHashtag_Id(Long recipeId, Long hashtagId);
 
+    void deleteByRecipe_Id(Long recipeId);
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagService.java
@@ -1,0 +1,6 @@
+package com.example.dgbackend.domain.recipe_hashtag.service;
+
+public interface RecipeHashTagService {
+
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagService.java
@@ -1,6 +1,13 @@
 package com.example.dgbackend.domain.recipe_hashtag.service;
 
+import com.example.dgbackend.domain.hashtag.HashTag;
+import com.example.dgbackend.domain.recipe.Recipe;
+import com.example.dgbackend.domain.recipe_hashtag.RecipeHashTag;
+
+import java.util.List;
+
 public interface RecipeHashTagService {
 
+    List<RecipeHashTag> uploadRecipeHashTag(Recipe recipe, List<String> hashTagName);
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagService.java
@@ -10,4 +10,6 @@ public interface RecipeHashTagService {
 
     List<RecipeHashTag> uploadRecipeHashTag(Recipe recipe, List<String> hashTagName);
 
+    void deleteRecipeHashTag(Long recipeId);
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagServiceImpl.java
@@ -41,4 +41,9 @@ public class RecipeHashTagServiceImpl implements RecipeHashTagService {
                 .toList();
     }
 
+    @Override
+    public void deleteRecipeHashTag(Long recipeId) {
+        recipeHashTagRepository.deleteByRecipe_Id(recipeId);
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagServiceImpl.java
@@ -34,7 +34,9 @@ public class RecipeHashTagServiceImpl implements RecipeHashTagService {
                             .hashtag(hashTag)
                             .build();
 
-                    return recipeHashTagRepository.save(recipeHashTag);
+                    //있으면 그대로 반환, 없으면 저장 후 반환
+                    return recipeHashTagRepository.findByRecipe_IdAndHashtag_Id(recipe.getId(), hashTag.getId())
+                            .orElseGet(() -> recipeHashTagRepository.save(recipeHashTag));
                 })
                 .toList();
     }

--- a/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagServiceImpl.java
@@ -1,13 +1,42 @@
 package com.example.dgbackend.domain.recipe_hashtag.service;
 
+import com.example.dgbackend.domain.hashtag.HashTag;
+import com.example.dgbackend.domain.hashtag.repository.HashTagRepository;
+import com.example.dgbackend.domain.hashtag.service.HashTagCommandServiceImpl;
+import com.example.dgbackend.domain.recipe.Recipe;
+import com.example.dgbackend.domain.recipe_hashtag.RecipeHashTag;
 import com.example.dgbackend.domain.recipe_hashtag.repository.RecipeHashTagRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
-public class RecipeHashTagServiceImpl implements RecipeHashTagService{
+public class RecipeHashTagServiceImpl implements RecipeHashTagService {
 
     private final RecipeHashTagRepository recipeHashTagRepository;
+    private final HashTagCommandServiceImpl hashTagCommandService;
+    private final HashTagRepository hashTagRepository;
+
+    @Override
+    @Transactional
+    public List<RecipeHashTag> uploadRecipeHashTag(Recipe recipe, List<String> hashTagName) {
+
+        List<HashTag> hashTags = hashTagCommandService.getHashTags(hashTagName);
+
+        return hashTags.stream().map(hashTag -> {
+                    RecipeHashTag recipeHashTag = RecipeHashTag.builder()
+                            .recipe(recipe)
+                            .hashtag(hashTag)
+                            .build();
+
+                    return recipeHashTagRepository.save(recipeHashTag);
+                })
+                .toList();
+    }
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagServiceImpl.java
@@ -1,0 +1,13 @@
+package com.example.dgbackend.domain.recipe_hashtag.service;
+
+import com.example.dgbackend.domain.recipe_hashtag.repository.RecipeHashTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecipeHashTagServiceImpl implements RecipeHashTagService{
+
+    private final RecipeHashTagRepository recipeHashTagRepository;
+
+}


### PR DESCRIPTION
## 요약

- 프론트 요청에 의해 해시태그 기능 추가하였습니다.

## 상세 내용

- RecipeHashTag 도메인 추가하였습니다.
- Recipe Entity에 recipeHashTagList Set 형으로 추가하였습니다.

🎏 create
<img width="959" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/b36911f6-5cf3-47d4-89b9-3581a5bfafbe">

🎏 patch
<img width="957" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/99794552/cc078940-799f-495d-9bbe-c38f59278ece">

## 질문 및 이외 사항

-

## 이슈 번호
Close #112 