### PR TITLE
Fix: 오늘의 조합 좋아요 여부 로직 수정

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combinationlike/repository/CombinationLikeRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/repository/CombinationLikeRepository.java
@@ -10,7 +10,7 @@ public interface CombinationLikeRepository extends JpaRepository<CombinationLike
 
     void deleteByCombinationId(Long combinationId);
 
-    boolean existsByCombinationAndMember(Combination combination, Member member);
+    boolean existsByCombinationAndMemberAndStateIsTrue(Combination combination, Member member);
 
     Optional<CombinationLike> findByCombinationAndMember(Combination combination, Member member);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
@@ -27,7 +27,7 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
     @Override
     public boolean isCombinationLike(Combination combination, Member member) {
 
-        return combinationLikeRepository.existsByCombinationAndMember(combination, member);
+        return combinationLikeRepository.existsByCombinationAndMemberAndStateIsTrue(combination, member);
     }
 
     @Override


### PR DESCRIPTION
## 요약

- 좋아요 로직을 수정합니다.

## 상세 내용

- `existsByCombinationAndMember`  -> `existsByCombinationAndMemberAndStateIsTrue` 로 수정하였습니다.
- 따라서 State가 True가 아닐 때에는 False로 표기됩니다.

## 질문 및 이외 사항

-

## 이슈 번호

-