### PR TITLE
Fix: 오늘의 조합 API URL 및 댓글 DTO 수정

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/controller/CombinationController.java
@@ -70,7 +70,7 @@ public class CombinationController {
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "오늘의 조합 작성 성공")
     })
-    @PostMapping("/recommends/{recommendId}")
+    @PostMapping("/recommends")
     public ApiResponse<CombinationResponse.CombinationProcResult> writeCombination(
         @Parameter(hidden = true) @MemberObject Member loginMember,
         @RequestBody CombinationRequest.WriteCombination request)

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/dto/CombinationCommentResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/dto/CombinationCommentResponse.java
@@ -40,7 +40,7 @@ public class CombinationCommentResponse {
 
         return CommentPreViewResult.builder()
             .combinationCommentList(commentPreviewList)
-            .listSize(commentPreviewList.size())
+            .listSize(comments.getContent().size())
             .totalPage(comments.getTotalPages())
             .totalElements(comments.getTotalElements())
             .isFirst(comments.isFirst())

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/repository/CombinationCommentRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/repository/CombinationCommentRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CombinationCommentRepository extends JpaRepository<CombinationComment, Long> {
 
-    Page<CombinationComment> findAllByCombinationIdAndState(Long combinationId, boolean state,
+    Page<CombinationComment> findAllByCombinationIdAndStateIsTrue(Long combinationId,
         Pageable pageable);
 
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentQueryServiceImpl.java
@@ -23,8 +23,8 @@ public class CombinationCommentQueryServiceImpl implements CombinationCommentQue
     @Override
     public CommentPreViewResult getCommentsFromCombination(Long combinationId, Integer page) {
 
-        Page<CombinationComment> comments = combinationCommentRepository.findAllByCombinationIdAndState(
-            combinationId, true, PageRequest.of(page, 10));
+        Page<CombinationComment> comments = combinationCommentRepository.findAllByCombinationIdAndStateIsTrue(
+            combinationId, PageRequest.of(page, 10));
 
         return toCommentPreViewResult(comments);
 

--- a/src/main/java/com/example/dgbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/dgbackend/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.dgbackend.global.config;
 
 import com.example.dgbackend.global.jwt.filter.JwtAuthenticationFilter;
 import com.example.dgbackend.global.jwt.handler.CustomLogoutHandler;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,8 +15,6 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 
-import java.util.List;
-
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -27,34 +26,37 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .httpBasic(HttpBasicConfigurer::disable)
-                .csrf(CsrfConfigurer::disable)
-                .cors(corsCustomizer -> corsCustomizer.configurationSource(request -> {
-                    CorsConfiguration cors = new CorsConfiguration();
-                    cors.setAllowedOrigins(List.of("https://drink-gourmet.kro.kr", "http://localhost:8080")); // 추후 수정
-                    cors.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE"));
-                    // cookie 활성화
-                    cors.setAllowCredentials(true);
-                    // Authorization Header 노출
-                    cors.addExposedHeader("Authorization");
-                    return cors;
-                }))
-                .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(authorize ->
-                        authorize
-                                .requestMatchers(
-                                    "/v3/api-docs/**",
-                                    "/swagger-ui/**"
-                                        , "/favicon.ico"
-                                        , "/auth/**"
-                                        , "/logout"
-                                ).permitAll() // 추후에 hasRole() 설정
-                                .anyRequest().authenticated());
+            .httpBasic(HttpBasicConfigurer::disable)
+            .csrf(CsrfConfigurer::disable)
+            .cors(corsCustomizer -> corsCustomizer.configurationSource(request -> {
+                CorsConfiguration cors = new CorsConfiguration();
+                cors.setAllowedOrigins(
+                    List.of("https://drink-gourmet.kro.kr", "http://localhost:8080"));
+                cors.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE"));
+                // cookie 활성화
+                cors.setAllowCredentials(true);
+                // Authorization Header 노출
+                cors.addExposedHeader("Authorization");
+                return cors;
+            }))
+            .sessionManagement(
+                configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(authorize ->
+                authorize
+                    .requestMatchers(
+                        "/v3/api-docs/**"
+                        , "/swagger-ui/**"
+                        , "/**"
+                        , "/favicon.ico"
+                        , "/auth/**"
+                        , "/logout"
+                    ).permitAll()
+                    .anyRequest().permitAll());
         http
-                .logout((logout) ->
-                        logout
-                                .logoutUrl("/logout")
-                                .logoutSuccessHandler(customLogoutHandler));
+            .logout((logout) ->
+                logout
+                    .logoutUrl("/logout")
+                    .logoutSuccessHandler(customLogoutHandler));
 
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/example/dgbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/dgbackend/global/config/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                 .csrf(CsrfConfigurer::disable)
                 .cors(corsCustomizer -> corsCustomizer.configurationSource(request -> {
                     CorsConfiguration cors = new CorsConfiguration();
-                    cors.setAllowedOrigins(List.of("*", "https://drink-gourmet.kro.kr", "http://localhost:8080")); // 추후 수정
+                    cors.setAllowedOrigins(List.of("https://drink-gourmet.kro.kr", "http://localhost:8080")); // 추후 수정
                     cors.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE"));
                     // cookie 활성화
                     cors.setAllowCredentials(true);
@@ -43,13 +43,13 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize ->
                         authorize
                                 .requestMatchers(
-                                        "/swagger-ui/**"
+                                    "/v3/api-docs/**",
+                                    "/swagger-ui/**"
                                         , "/favicon.ico"
-                                        , "/**"
                                         , "/auth/**"
                                         , "/logout"
                                 ).permitAll() // 추후에 hasRole() 설정
-                                .anyRequest().permitAll());
+                                .anyRequest().authenticated());
         http
                 .logout((logout) ->
                         logout


### PR DESCRIPTION
## 요약

- 오늘의 조합 API URL {recommendId} 부분 제거
- 댓글 조회 응답값에서 자식 댓글을 카운트 못 하는 오류 해결

## 상세 내용

- 오늘의 조합 작성 API에서 path variable 삭제
- 댓글 조회 DTO 수정
```java
.listSize(comments.getContent().size())
```
> 댓글 자식도 카운트 되도록 함.

## 질문 및 이외 사항

-

## 이슈 번호

- close #140 