### PR TITLE
Refactor : 레시피 / 레시피 댓글에 유저 정보 추가

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/recipe/dto/RecipeResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/dto/RecipeResponse.java
@@ -1,5 +1,6 @@
 package com.example.dgbackend.domain.recipe.dto;
 
+import com.example.dgbackend.domain.member.dto.MemberResponse;
 import com.example.dgbackend.domain.recipe.Recipe;
 import com.example.dgbackend.domain.recipe_hashtag.dto.RecipeHashTagResponse;
 import com.example.dgbackend.domain.recipeimage.RecipeImage;
@@ -59,8 +60,8 @@ public class RecipeResponse {
     @Schema(description = "존재 여부", example = "true")
     private boolean state = true; //true : 존재, false : 삭제
 
-    @Schema(description = "작성자 닉네임", example = "mason")
-    private String memberNickName;
+    @Schema(description = "작성자 정보")
+    private MemberResponse.MemberResult member;
 
     @Schema(description = "레시피 이미지 목록")
     private List<String> recipeImageList;
@@ -108,7 +109,7 @@ public class RecipeResponse {
                 .recipeInstruction(recipe.getRecipeInstruction())
                 .recommendCombination(recipe.getRecommendCombination())
                 .state(recipe.isState())
-                .memberNickName(recipe.getMember().getNickName())
+                .member(MemberResponse.toMemberResult(recipe.getMember()))
                 .recipeImageList(RecipeImageResponse.toStringResponse(recipe.getRecipeImageList()))
                 .hashTagNameList(RecipeHashTagResponse.toStringResponse(recipe.getRecipeHashTagList()))
                 .isLike(isLike)

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/dto/RecipeCommentResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/dto/RecipeCommentResponse.java
@@ -1,5 +1,6 @@
 package com.example.dgbackend.domain.recipecomment.dto;
 
+import com.example.dgbackend.domain.member.dto.MemberResponse;
 import com.example.dgbackend.domain.recipecomment.RecipeComment;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -28,11 +29,8 @@ public class RecipeCommentResponse {
     @Schema(description = "댓글 내용", example = "맛있어요")
     private String content;
 
-    @Schema(description = "작성자 닉니임 ", example = "mason")
-    private String memberNickName;
-
-    @Schema(description = "작성자 이미지", example = "https://image.com")
-    private String memberImage;
+    @Schema(description = "작성자 정보")
+    private MemberResponse.MemberResult member;
 
     @Schema(description = "작성일", example = "2021-08-01 12:00:00")
     private LocalDateTime createdDate;
@@ -88,8 +86,7 @@ public class RecipeCommentResponse {
                 .id(recipeComment.getId())
                 .content(recipeComment.getContent())
                 .childCommentList(getList(recipeComment))
-                .memberNickName(recipeComment.getMember().getNickName())
-                .memberImage(recipeComment.getMember().getProfileImageUrl())
+                .member(MemberResponse.toMemberResult(recipeComment.getMember()))
                 .createdDate(recipeComment.getCreatedAt())
                 .updatedDate(recipeComment.getUpdatedAt())
                 .childCommentCount(childCommentCount)


### PR DESCRIPTION
## 요약

- 레시피 / 레시피 댓글에 유저 정보 추가

## 상세 내용

- 레시피 / 레시피 댓글에 유저 정보 추가하였습니다
- 기존 MemberResponse에 만들어진 클래스가 있어 활용하였습니다

## 질문 및 이외 사항

-

## 이슈 번호
Close  #149 
-