### PR TITLE
Fix: 검색 시 State True 게시글만 조회

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
@@ -24,7 +24,7 @@ public interface CombinationRepository extends JpaRepository<Combination, Long> 
     @Query("SELECT cl.combination FROM CombinationLike cl WHERE cl.member.id = :memberId AND cl.combination.state = true")
     Page<Combination> findCombinationsByMemberIdAndStateIsTrue(Long memberId, PageRequest pageRequest);
 
-    Page<Combination> findCombinationsByTitleContaining(String keyword, PageRequest pageRequest);
+    Page<Combination> findCombinationsByTitleContainingAndStateIsTrue(String keyword, PageRequest pageRequest);
 
     Page<Combination> findCombinationsByTitleContainingAndLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
         String keyword, PageRequest pageRequest, Long likeCount);

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -1,6 +1,14 @@
 package com.example.dgbackend.domain.combination.service;
 
-import static com.example.dgbackend.domain.combination.dto.CombinationResponse.*;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationDetailResult;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationEditResult;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationMyPageList;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationPreviewResultList;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.CombinationResult;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.toCombinationDetailResult;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.toCombinationMyPageList;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.toCombinationPreviewResultList;
+import static com.example.dgbackend.domain.combination.dto.CombinationResponse.toCombinationResult;
 import static com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentResponse.CommentPreViewResult;
 import static com.example.dgbackend.domain.member.dto.MemberResponse.toMemberResult;
 
@@ -9,17 +17,14 @@ import com.example.dgbackend.domain.combination.dto.CombinationResponse;
 import com.example.dgbackend.domain.combination.repository.CombinationRepository;
 import com.example.dgbackend.domain.combinationcomment.service.CombinationCommentQueryService;
 import com.example.dgbackend.domain.combinationimage.CombinationImage;
-import com.example.dgbackend.domain.combinationimage.repository.CombinationImageRepository;
 import com.example.dgbackend.domain.combinationlike.service.CombinationLikeQueryService;
 import com.example.dgbackend.domain.hashtagoption.HashTagOption;
-import com.example.dgbackend.domain.hashtagoption.repository.HashTagOptionRepository;
 import com.example.dgbackend.domain.hashtagoption.service.HashTagOptionQueryService;
 import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.member.dto.MemberResponse;
 import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
 import com.example.dgbackend.global.exception.ApiException;
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -141,8 +146,9 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
      */
     @Override
     public CombinationResponse.CombinationMyPageList getCombinationMyPageList(Member member,
-                                                                              Integer page) {
-        Page<Combination> combinations = combinationRepository.findAllByMemberIdAndStateIsTrue(member.getId(), PageRequest.of(page, 21));
+        Integer page) {
+        Page<Combination> combinations = combinationRepository.findAllByMemberIdAndStateIsTrue(
+            member.getId(), PageRequest.of(page, 21));
 
         return toCombinationMyPageList(combinations);
     }
@@ -171,8 +177,9 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
      */
     @Override
     public CombinationMyPageList getCombinationLikeList(Member member,
-                                                        Integer page) {
-        Page<Combination> combinations = combinationRepository.findCombinationsByMemberIdAndStateIsTrue(member.getId(), PageRequest.of(page, 21));
+        Integer page) {
+        Page<Combination> combinations = combinationRepository.findCombinationsByMemberIdAndStateIsTrue(
+            member.getId(), PageRequest.of(page, 21));
 
         return toCombinationMyPageList(combinations);
     }
@@ -184,7 +191,7 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
         String keyword) {
         PageRequest pageRequest = PageRequest.of(page, 10);
 
-        Page<Combination> combinations = combinationRepository.findCombinationsByTitleContaining(
+        Page<Combination> combinations = combinationRepository.findCombinationsByTitleContainingAndStateIsTrue(
             keyword, pageRequest);
 
         List<Combination> combinationList = combinations.getContent();
@@ -206,16 +213,16 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
         PageRequest pageRequest = PageRequest.of(page, 10);
 
         Page<Combination> combinations = combinationRepository.findCombinationsByTitleContainingAndLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
-                keyword, pageRequest, 30L);
+            keyword, pageRequest, 30L);
 
         List<Combination> combinationList = combinations.getContent();
         List<List<HashTagOption>> hashTagOptionList = combinationList.stream()
-                .map(hashTagOptionQueryService::getAllHashTagOptionByCombination)
-                .toList();
+            .map(hashTagOptionQueryService::getAllHashTagOptionByCombination)
+            .toList();
 
         List<Boolean> isLikeList = combinationList.stream()
-                .map(cb -> combinationLikeQueryService.isCombinationLike(cb, loginMember))
-                .toList();
+            .map(cb -> combinationLikeQueryService.isCombinationLike(cb, loginMember))
+            .toList();
 
         return toCombinationPreviewResultList(combinations, hashTagOptionList, isLikeList);
     }

--- a/src/main/java/com/example/dgbackend/domain/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/repository/RecipeRepository.java
@@ -19,7 +19,7 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
     @Query("SELECT rl.recipe FROM RecipeLike rl WHERE rl.member.id = :memberId AND rl.recipe.state = true")
     Page<Recipe> findRecipesByMemberIdAndStateIsTrue(Long memberId, PageRequest pageRequest);
 
-    Page<Recipe> findRecipesByTitleContaining(String keyword, Pageable pageable);
+    Page<Recipe> findRecipesByTitleContainingAndStateIsTrue(String keyword, Pageable pageable);
 
     Page<Recipe> findAllByStateIsTrueOrderByLikeCountDesc(PageRequest pageRequest);
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
@@ -134,7 +134,7 @@ public class RecipeServiceImpl implements RecipeService {
 
         Pageable pageable = Pageable.ofSize(10).withPage(page);
 
-        Page<Recipe> recipesByKeyword = recipeRepository.findRecipesByTitleContaining(keyword, pageable);
+        Page<Recipe> recipesByKeyword = recipeRepository.findRecipesByTitleContainingAndStateIsTrue(keyword, pageable);
 
         List<RecipeResponse> recipeResponseList = recipesByKeyword.getContent().stream()
                 .map(recipe -> {


### PR DESCRIPTION
## 요약

- 게시글 검색 시 삭제된 게시글도 검색되는 오류를 수정하였습니다.

## 상세 내용

- JPA 메서드를 수정하여 State가 True인 게시글들만 조회합니다.
- `findCombinationsByTitleContaining` -> `findCombinationsByTitleContainingAndStateIsTrue` 로 수정
## 질문 및 이외 사항

-

## 이슈 번호

-