### PR TITLE
refactor: 좋아요 삭제 여부 반영

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
@@ -21,7 +21,7 @@ public interface CombinationRepository extends JpaRepository<Combination, Long> 
     Page<Combination> findCombinationsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
         Long likeCount, PageRequest pageRequest);
 
-    @Query("SELECT cl.combination FROM CombinationLike cl WHERE cl.member.id = :memberId AND cl.combination.state = true")
+    @Query("SELECT cl.combination FROM CombinationLike cl WHERE cl.member.id = :memberId AND cl.combination.state = true AND cl.state = true")
     Page<Combination> findCombinationsByMemberIdAndStateIsTrue(Long memberId, PageRequest pageRequest);
 
     Page<Combination> findCombinationsByTitleContainingAndStateIsTrue(String keyword, PageRequest pageRequest);

--- a/src/main/java/com/example/dgbackend/domain/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/repository/RecipeRepository.java
@@ -16,7 +16,7 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
     Page<Recipe> findAllByMemberIdAndStateIsTrue(Long memberId, PageRequest pageRequest);
 
-    @Query("SELECT rl.recipe FROM RecipeLike rl WHERE rl.member.id = :memberId AND rl.recipe.state = true")
+    @Query("SELECT rl.recipe FROM RecipeLike rl WHERE rl.member.id = :memberId AND rl.recipe.state = true AND rl.state = true")
     Page<Recipe> findRecipesByMemberIdAndStateIsTrue(Long memberId, PageRequest pageRequest);
 
     Page<Recipe> findRecipesByTitleContainingAndStateIsTrue(String keyword, Pageable pageable);


### PR DESCRIPTION
## 요약

- 좋아요 삭제 여부가 조회할 때 반영 안 되는 부분 수정.

## 상세 내용

- 각 Repository에 해당 Like 테이블 state 값 true인 것만 불러오는 부분 추가 
- 포스트맨 호출 
<img width="1470" alt="스크린샷 2024-02-19 오후 10 16 20" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/101540728/65114f98-73da-4491-a5ff-7c16f6162373">
- DB
<img width="1470" alt="스크린샷 2024-02-19 오후 10 16 29" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/101540728/339d5a07-21e3-4bee-b329-1a4ba9689abc">

## 질문 및 이외 사항

-

## 이슈 번호

- #156 