### PR TITLE
Fix: 신고당한 Member Id 추가 및 댓글 생성 오류 해결

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/dto/CombinationCommentRequest.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/dto/CombinationCommentRequest.java
@@ -2,36 +2,38 @@ package com.example.dgbackend.domain.combinationcomment.dto;
 
 import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.combinationcomment.CombinationComment;
+import com.example.dgbackend.domain.enums.State;
 import com.example.dgbackend.domain.member.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 public class CombinationCommentRequest {
 
-    @Getter
-    @Schema(name = "오늘의 조합 댓글 작성 요청 DTO")
-    public static class WriteComment {
+	@Getter
+	@Schema(name = "오늘의 조합 댓글 작성 요청 DTO")
+	public static class WriteComment {
 
-        private String content;
-        private Long parentId;
-    }
+		private String content;
+		private Long parentId;
+	}
 
-    public static CombinationComment toCombinationComment(Combination combination, Member member,
-                                                          String content, CombinationComment parentComment) {
+	public static CombinationComment toCombinationComment(Combination combination, Member member,
+		String content, CombinationComment parentComment) {
 
-        return CombinationComment.builder()
-                .content(content)
-                .parentComment(parentComment)
-                .member(member)
-                .combination(combination)
-                .build();
-    }
+		return CombinationComment.builder()
+			.content(content)
+			.parentComment(parentComment)
+			.member(member)
+			.combination(combination)
+			.state(State.TRUE)
+			.build();
+	}
 
-    @Getter
-    @Schema(name = "오늘의 조합 댓글 수정 요청 DTO")
-    public static class UpdateComment {
+	@Getter
+	@Schema(name = "오늘의 조합 댓글 수정 요청 DTO")
+	public static class UpdateComment {
 
-        private String content;
-    }
+		private String content;
+	}
 
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/repository/CombinationCommentRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/repository/CombinationCommentRepository.java
@@ -14,4 +14,7 @@ public interface CombinationCommentRepository extends JpaRepository<CombinationC
 	Page<CombinationComment> findByCombinationIdAndStateTrueOrReported(@Param("combinationId") Long combinationId, Pageable pageable);
 
 	Optional<CombinationComment> findByIdAndStateIsTrue(Long id);
+
+	@Query("SELECT c FROM CombinationComment c WHERE c.id = :id AND c.state = 'TRUE'")
+	Optional<CombinationComment> findByIdAndStateTrue(@Param("id") Long id);
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/repository/RecipeCommentRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/repository/RecipeCommentRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RecipeCommentRepository extends JpaRepository<RecipeComment, Long> {
     List<RecipeComment> findAllByRecipe(Recipe recipe);
@@ -18,4 +19,7 @@ public interface RecipeCommentRepository extends JpaRepository<RecipeComment, Lo
     Page<RecipeComment> findByRecipeAndParentCommentIsNullAndStateIsTrueOrReported(Recipe recipe, Pageable pageable);
 
     Optional<RecipeComment> findByIdAndStateIsTrue(Long id);
+
+    @Query("SELECT r FROM RecipeComment r WHERE r.id = :id AND r.state = 'TRUE'")
+    Optional<RecipeComment> findByIdAndStateTrue(@Param("id")Long id);
 }

--- a/src/main/java/com/example/dgbackend/domain/report/dto/ReportRequest.java
+++ b/src/main/java/com/example/dgbackend/domain/report/dto/ReportRequest.java
@@ -17,6 +17,7 @@ public class ReportRequest {
 		ReportReason reportReason; // 신고 사유
 		String content; // 신고 사유(내용)
 		String reportContent; // 신고 대상 내용
+		Long reportedMemberId; // 신고당한 멤버 id
 	}
 
 }

--- a/src/main/java/com/example/dgbackend/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/report/service/ReportServiceImpl.java
@@ -80,7 +80,7 @@ public class ReportServiceImpl implements ReportService {
 				sendReportMail(reportReq, member);
 			}
 			case COMBINATION_COMMENT -> {
-				CombinationComment combinationComment = combinationCommentRepository.findByIdAndStateIsTrue(
+				CombinationComment combinationComment = combinationCommentRepository.findByIdAndStateTrue(
 						reportReq.getResourceId())
 					.orElseThrow(
 						() -> new ApiException(ErrorStatus._COMBINATION_COMMENT_NOT_FOUND));
@@ -89,7 +89,7 @@ public class ReportServiceImpl implements ReportService {
 				sendReportMail(reportReq, member);
 			}
 			case RECIPE_COMMENT -> {
-				RecipeComment recipeComment = recipeCommentRepository.findByIdAndStateIsTrue(
+				RecipeComment recipeComment = recipeCommentRepository.findByIdAndStateTrue(
 						reportReq.getResourceId())
 					.orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE_COMMENT));
 				recipeComment.updateState();


### PR DESCRIPTION
Related: #171

## 요약

- 신고당한 Member Id를 받아와서 회원 정지시킬 수 있도록 수정하고 댓글 생성 시 오류를 해결합니다.

## 상세 내용

-

## 질문 및 이외 사항

-

## 이슈 번호

-