### PR TITLE
Fix: 커뮤니티 검색 시 최신순으로 조회

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
@@ -25,7 +25,7 @@ public interface CombinationRepository extends JpaRepository<Combination, Long> 
     @Query("SELECT cl.combination FROM CombinationLike cl WHERE cl.member.id = :memberId AND cl.combination.state = true AND cl.state = true")
     Page<Combination> findCombinationsByMemberIdAndStateIsTrue(Long memberId, PageRequest pageRequest);
 
-    Page<Combination> findCombinationsByTitleContainingAndStateIsTrue(String keyword, PageRequest pageRequest);
+    Page<Combination> findCombinationsByTitleContainingAndStateIsTrueOrderByCreatedAtDesc(String keyword, PageRequest pageRequest);
 
     Page<Combination> findCombinationsByTitleContainingAndLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
         String keyword, PageRequest pageRequest, Long likeCount);

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -192,7 +192,7 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
         String keyword) {
         PageRequest pageRequest = PageRequest.of(page, 10);
 
-        Page<Combination> combinations = combinationRepository.findCombinationsByTitleContainingAndStateIsTrue(
+        Page<Combination> combinations = combinationRepository.findCombinationsByTitleContainingAndStateIsTrueOrderByCreatedAtDesc(
             keyword, pageRequest);
 
         List<Combination> combinationList = combinations.getContent();

--- a/src/main/java/com/example/dgbackend/domain/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/repository/RecipeRepository.java
@@ -20,7 +20,7 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
     @Query("SELECT rl.recipe FROM RecipeLike rl WHERE rl.member.id = :memberId AND rl.recipe.state = true AND rl.state = true")
     Page<Recipe> findRecipesByMemberIdAndStateIsTrue(Long memberId, PageRequest pageRequest);
 
-    Page<Recipe> findRecipesByTitleContainingAndStateIsTrue(String keyword, Pageable pageable);
+    Page<Recipe> findRecipesByTitleContainingAndStateIsTrueOrderByCreatedAtDesc(String keyword, Pageable pageable);
 
     Page<Recipe> findAllByStateIsTrueOrderByLikeCountDesc(PageRequest pageRequest);
 

--- a/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
@@ -133,7 +133,7 @@ public class RecipeServiceImpl implements RecipeService {
 
         Pageable pageable = Pageable.ofSize(10).withPage(page);
 
-        Page<Recipe> recipesByKeyword = recipeRepository.findRecipesByTitleContainingAndStateIsTrue(keyword, pageable);
+        Page<Recipe> recipesByKeyword = recipeRepository.findRecipesByTitleContainingAndStateIsTrueOrderByCreatedAtDesc(keyword, pageable);
 
         List<RecipeResponse> recipeResponseList = recipesByKeyword.getContent().stream()
                 .map(recipe -> {


### PR DESCRIPTION
## 요약

- 커뮤니티 검색 시 최신순으로 조회하도록 메서드를 수정합니다.

## 상세 내용

- JPA 메서드에 `OrderByCreatedAtDesc` 를 추가하였습니다.

## 질문 및 이외 사항

-

## 이슈 번호

- close #178 