### PR TITLE
Feat: 차단 API 구현

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
@@ -11,31 +11,42 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface CombinationRepository extends JpaRepository<Combination, Long> {
 
-    Page<Combination> findAllByMemberIdAndStateIsTrueOrderByCreatedAtDesc(Long memberId, PageRequest pageRequest);
+	Page<Combination> findAllByMemberIdAndStateIsTrueOrderByCreatedAtDesc(Long memberId,
+		PageRequest pageRequest);
 
-    List<Combination> findAllByMember(Member member);
+	List<Combination> findAllByMember(Member member);
 
-    Page<Combination> findAllByStateOrderByCreatedAtDesc(Boolean state, PageRequest pageRequest);
+	@Query("SELECT c FROM Combination c WHERE c.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND c.state = :state ORDER BY c.createdAt DESC")
+	Page<Combination> findAllByStateOrderByCreatedAtDesc(Boolean state, PageRequest pageRequest,
+		Long memberId);
 
-    Boolean existsByIdAndMember(Long combinationId, Member member);
+	Boolean existsByIdAndMember(Long combinationId, Member member);
 
-    Page<Combination> findCombinationsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
-        Long likeCount, PageRequest pageRequest);
+	@Query("SELECT c FROM Combination c WHERE c.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND c.likeCount >= :likeCount AND c.state = true ORDER BY c.createdAt DESC")
+	Page<Combination> findCombinationsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
+		Long likeCount, PageRequest pageRequest, Long memberId);
 
-    @Query("SELECT cl.combination FROM CombinationLike cl WHERE cl.member.id = :memberId AND cl.combination.state = true AND cl.state = true")
-    Page<Combination> findCombinationsByMemberIdAndStateIsTrue(Long memberId, PageRequest pageRequest);
+	@Query("SELECT cl.combination FROM CombinationLike cl WHERE cl.member.id = :memberId AND cl.combination.state = true AND cl.state = true")
+	Page<Combination> findCombinationsByMemberIdAndStateIsTrue(Long memberId,
+		PageRequest pageRequest);
 
-    Page<Combination> findCombinationsByTitleContainingAndStateIsTrueOrderByCreatedAtDesc(String keyword, PageRequest pageRequest);
+	@Query("SELECT c FROM Combination c WHERE c.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND c.title LIKE %:keyword% AND c.state = true ORDER BY c.createdAt DESC")
+	Page<Combination> findCombinationsByTitleContainingAndStateIsTrueOrderByCreatedAtDesc(
+		String keyword, PageRequest pageRequest, Long memberId);
 
-    Page<Combination> findCombinationsByTitleContainingAndLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
-        String keyword, PageRequest pageRequest, Long likeCount);
+	@Query("SELECT c FROM Combination c WHERE c.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND c.title LIKE %:keyword% AND c.likeCount >= :likeCount AND c.state = true ORDER BY c.createdAt DESC")
+	Page<Combination> findCombinationsByTitleContainingAndLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
+		String keyword, PageRequest pageRequest, Long likeCount, Long memberId);
 
     @Query("SELECT c FROM Combination c WHERE c.likeCount >= 30 AND c.state = true ORDER BY RAND() LIMIT 5")
     List<Combination> findCombinationsByLikeCountGreaterThanEqualAndStateIsTrue();
 
     Page<Combination> findAllByStateIsTrueOrderByLikeCountDesc(PageRequest pageRequest);
 
-    boolean existsByIdAndState(Long combinationId, boolean state);
+	boolean existsByIdAndState(Long combinationId, boolean state);
 
-    Optional<Combination> findByIdAndStateIsTrue(Long id);
+	Optional<Combination> findByIdAndStateIsTrue(Long id);
+
+	@Query("SELECT c FROM Combination c WHERE c.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND c.id = :id AND c.state = true")
+	Optional<Combination> findCombinationByIdAndStateIsTrue(Long id, Long memberId);
 }

--- a/src/main/java/com/example/dgbackend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/member/repository/MemberRepository.java
@@ -14,4 +14,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Boolean existsByProviderAndProviderId(String provider, String providerId);
 
     Optional<Member> findByProviderAndProviderId(String provider, String providerId);
+
+    Optional<Member> findMemberById(Long id);
 }

--- a/src/main/java/com/example/dgbackend/domain/memberblock/MemberBlock.java
+++ b/src/main/java/com/example/dgbackend/domain/memberblock/MemberBlock.java
@@ -1,0 +1,45 @@
+package com.example.dgbackend.domain.memberblock;
+
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.memberblock.dto.MemberBlockRequest.MemberBlockReq;
+import com.example.dgbackend.global.common.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class MemberBlock extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member; // 차단 주체 memberId
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "blocked_member_id")
+	private Member blockedMember; // 차단 당한 memberId
+
+	public static MemberBlock toEntity(Member blockedMember, Member currentMember) {
+		return MemberBlock.builder()
+			.blockedMember(blockedMember)
+			.member(currentMember)
+			.build();
+	}
+
+}

--- a/src/main/java/com/example/dgbackend/domain/memberblock/controller/MemberBlockController.java
+++ b/src/main/java/com/example/dgbackend/domain/memberblock/controller/MemberBlockController.java
@@ -1,0 +1,28 @@
+package com.example.dgbackend.domain.memberblock.controller;
+
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.memberblock.dto.MemberBlockRequest.MemberBlockReq;
+import com.example.dgbackend.domain.memberblock.dto.MemberBlockResponse;
+import com.example.dgbackend.domain.memberblock.service.MemberBlockServiceImpl;
+import com.example.dgbackend.global.common.response.ApiResponse;
+import com.example.dgbackend.global.jwt.annotation.MemberObject;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberBlockController {
+
+	private final MemberBlockServiceImpl memberBlockService;
+
+	@PostMapping("/member/blocks")
+	public ApiResponse<MemberBlockResponse.MemberBlockResult> block(
+		@RequestBody MemberBlockReq memberBlockReq, @MemberObject
+	Member member) {
+		return ApiResponse.onSuccess(memberBlockService.block(memberBlockReq, member));
+	}
+
+
+}

--- a/src/main/java/com/example/dgbackend/domain/memberblock/dto/MemberBlockRequest.java
+++ b/src/main/java/com/example/dgbackend/domain/memberblock/dto/MemberBlockRequest.java
@@ -1,0 +1,18 @@
+package com.example.dgbackend.domain.memberblock.dto;
+
+import com.example.dgbackend.domain.member.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MemberBlockRequest {
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class MemberBlockReq {
+
+		Long blockedMemberId; // 차단 대상 member id
+	}
+
+}

--- a/src/main/java/com/example/dgbackend/domain/memberblock/dto/MemberBlockResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/memberblock/dto/MemberBlockResponse.java
@@ -1,0 +1,28 @@
+package com.example.dgbackend.domain.memberblock.dto;
+
+import com.example.dgbackend.domain.member.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MemberBlockResponse {
+
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Getter
+	public static class MemberBlockResult {
+
+		Long memberId;
+		Long blockedMemberId;
+	}
+
+	public static MemberBlockResult toMemberBlockResult(Member blockedMember, Member member) {
+		return MemberBlockResult.builder()
+			.blockedMemberId(blockedMember.getId())
+			.memberId(member.getId())
+			.build();
+	}
+
+}

--- a/src/main/java/com/example/dgbackend/domain/memberblock/repository/MemberBlockRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/memberblock/repository/MemberBlockRepository.java
@@ -1,0 +1,10 @@
+package com.example.dgbackend.domain.memberblock.repository;
+
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.memberblock.MemberBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberBlockRepository extends JpaRepository<MemberBlock, Long> {
+
+	MemberBlock findMemberBlockByMemberAndBlockedMember(Member member, Member blockedMember);
+}

--- a/src/main/java/com/example/dgbackend/domain/memberblock/service/MemberBlockService.java
+++ b/src/main/java/com/example/dgbackend/domain/memberblock/service/MemberBlockService.java
@@ -1,0 +1,11 @@
+package com.example.dgbackend.domain.memberblock.service;
+
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.memberblock.dto.MemberBlockRequest.MemberBlockReq;
+import com.example.dgbackend.domain.memberblock.dto.MemberBlockResponse.MemberBlockResult;
+
+public interface MemberBlockService {
+
+	MemberBlockResult block(MemberBlockReq memberBlockReq, Member member);
+
+}

--- a/src/main/java/com/example/dgbackend/domain/memberblock/service/MemberBlockServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/memberblock/service/MemberBlockServiceImpl.java
@@ -1,0 +1,46 @@
+package com.example.dgbackend.domain.memberblock.service;
+
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.member.repository.MemberRepository;
+import com.example.dgbackend.domain.memberblock.MemberBlock;
+import com.example.dgbackend.domain.memberblock.dto.MemberBlockRequest.MemberBlockReq;
+import com.example.dgbackend.domain.memberblock.dto.MemberBlockResponse;
+import com.example.dgbackend.domain.memberblock.dto.MemberBlockResponse.MemberBlockResult;
+import com.example.dgbackend.domain.memberblock.repository.MemberBlockRepository;
+import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
+import com.example.dgbackend.global.exception.ApiException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberBlockServiceImpl implements MemberBlockService {
+
+	private final MemberBlockRepository memberBlockRepository;
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public MemberBlockResult block(MemberBlockReq memberBlockReq, Member member) {
+
+		Member blockedMember = memberRepository.findMemberById(memberBlockReq.getBlockedMemberId())
+			.orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_MEMBER));
+
+		MemberBlock prevMemberBlock = memberBlockRepository.findMemberBlockByMemberAndBlockedMember(blockedMember, member);
+
+		duplicateMemberBlock(prevMemberBlock);
+
+		MemberBlock memberBlock = MemberBlock.toEntity(blockedMember, member);
+
+		memberBlockRepository.save(memberBlock);
+
+		return MemberBlockResponse.toMemberBlockResult(blockedMember, member);
+	}
+
+	private void duplicateMemberBlock(MemberBlock prevMemberBlock) {
+		if (prevMemberBlock != null) {
+			throw new ApiException(ErrorStatus._DUPLICATE_MEMBER_BLOCK);
+		}
+	}
+
+}

--- a/src/main/java/com/example/dgbackend/domain/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/repository/RecipeRepository.java
@@ -11,7 +11,8 @@ import java.util.List;
 
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
-    Page<Recipe> findAllByStateOrderByCreatedAtDesc(boolean state, Pageable pageable);
+    @Query("SELECT r FROM Recipe r WHERE r.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND r.state = :state ORDER BY r.createdAt DESC")
+    Page<Recipe> findAllByStateOrderByCreatedAtDesc(boolean state, Pageable pageable, Long memberId);
 
     List<Recipe> findAllByTitleAndMember_Name(String name, String memberName);
 
@@ -20,9 +21,13 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
     @Query("SELECT rl.recipe FROM RecipeLike rl WHERE rl.member.id = :memberId AND rl.recipe.state = true AND rl.state = true")
     Page<Recipe> findRecipesByMemberIdAndStateIsTrue(Long memberId, PageRequest pageRequest);
 
-    Page<Recipe> findRecipesByTitleContainingAndStateIsTrueOrderByCreatedAtDesc(String keyword, Pageable pageable);
+    @Query("SELECT r FROM Recipe r WHERE r.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND r.title LIKE %:keyword% AND r.state = true ORDER BY r.createdAt DESC")
+    Page<Recipe> findRecipesByTitleContainingAndStateIsTrueOrderByCreatedAtDesc(String keyword, Pageable pageable, Long memberId);
 
     Page<Recipe> findAllByStateIsTrueOrderByLikeCountDesc(PageRequest pageRequest);
 
     Optional<Recipe> findByIdAndStateIsTrue(Long id);
+
+    @Query("SELECT r FROM Recipe r WHERE r.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND r.id = :id AND r.state = true")
+    Optional<Recipe> findByIdAndMemberAndStateIsTrue(Long id, Long memberId);
 }

--- a/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
@@ -73,7 +73,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _FAIL_SEND_MAIL(HttpStatus.INTERNAL_SERVER_ERROR, "REPORT_002", "메일 전송에 실패했습니다."),
 
     //차단
-    _DUPLICATE_MEMBER_BLOCK(HttpStatus.CONFLICT,"MEMBER_BLOCK_001", "이미 차단된 멤버입니다.");
+    _DUPLICATE_MEMBER_BLOCK(HttpStatus.CONFLICT,"MEMBER_BLOCK_001", "이미 차단된 멤버입니다."),
+    _BLOCKED_MEMBER(HttpStatus.CONFLICT,"MEMBER_BLOCK_002", "차단된 멤버입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
@@ -68,8 +68,12 @@ public enum ErrorStatus implements BaseErrorCode {
     //새로 출시된 주류
     _EMPTY_DRINK_LIST(HttpStatus.CONFLICT, "DRINK_001", "존재하지 않는 주류입니다."),
 
-    _DUPLICATE_REPORT(HttpStatus.CONFLICT, "REPORT_001", "이미 존재하는 신고 내용입니다"),
-    _FAIL_SEND_MAIL(HttpStatus.INTERNAL_SERVER_ERROR, "REPORT_002", "메일 전송에 실패했습니다.");
+    // 신고
+    _DUPLICATE_REPORT(HttpStatus.CONFLICT, "REPORT_001", "이미 존재하는 신고 내용입니다."),
+    _FAIL_SEND_MAIL(HttpStatus.INTERNAL_SERVER_ERROR, "REPORT_002", "메일 전송에 실패했습니다."),
+
+    //차단
+    _DUPLICATE_MEMBER_BLOCK(HttpStatus.CONFLICT,"MEMBER_BLOCK_001", "이미 차단된 멤버입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 요약

- 차단 API 관련한 기능을 개발하였습니다.

## 상세 내용

- 오늘의 조합, 주간 베스트 조합 "조회" 관련 API를 MemberBlock 테이블에 따라 조회 쿼리문을 수정하였습니다.
- 레시피 관련 "조회" API를 MemberBlock 테이블에 따라 조회 쿼리문을 수정하였습니다.

# MemberBlock
<img width="887" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/125117389/bab6fd67-1a92-44b2-b663-02fced99e1a2">

- MemberBlock 테이블에 아무 값도 없는 형태입니다. 이 상상태에서 아래와 같은 요청을 보냅니다.

<img width="634" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/125117389/4b2afc02-2f3c-44b1-ae71-c05913a158af">

- 그러면 아래와 같이 MemberBlock 테이블에 데이터가 생기게 됩니다.
<img width="876" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/125117389/2fd8b17f-d599-47e8-87a8-74e7e54bf966">

```java
@Query("SELECT c FROM Combination c WHERE c.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND c.state = :state ORDER BY c.createdAt DESC")
Page<Combination> findAllByStateOrderByCreatedAtDesc(Boolean state, PageRequest pageRequest, Long memberId);
```
- 그렇게 생기게 된 DB에 따라 위와 같은 쿼리문을 통해 MemberBlock 테이블에 있는 멤버라면 제외하고 글을 조회하게 됩니다.
- 레시피에서도 동일하게 적용됩니다.


```java
    private void isBlocked(Long combinationId, Long memberId) {
        Combination blockedCombination = combinationRepository.findCombinationByIdAndStateIsTrue(
                combinationId, memberId)
            .orElseThrow(() -> new ApiException(ErrorStatus._BLOCKED_MEMBER));
    }
```
- 위와 같은 isBlocked 메서드를 통해 상세 조회 시 차단한 멤버의 글이라면 예외 처리합니다. 레시피에서도 동일하게 적용됩니다.

### 차단 시 조회 테스트 (1번 멤버가 2번 멤버를 차단할 경우)
<img width="712" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/125117389/49334db7-2194-42c4-9874-d3769f682177">

- 차단하기 전 조합 글 조회입니다. combinationId 값이 3인 Combination 글이 2번 멤버가 작성한 글입니다.

<img width="604" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/125117389/762cb0f0-0ba9-4a65-816b-deda998043b6">

- 차단하고 난 뒤에는 해당 글이 조회되지 않습니다.

<img width="765" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/125117389/da00577e-3c12-4f8a-9b2c-ec0d2730562f">

- 검색시에도 차단된 멤버의 글은 조회되지 않습니다.

<img width="470" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/125117389/31570c78-1d39-4097-9cfe-962e52b650d3">

- 메인페이지에서 차단된 멤버의 글을 상세조회 할 경우, [차단된 멤버입니다] 라는 오류를 반환하며 예외처리하였습니다.

위의 동작은 레시피글 조회, 검색, 상세조회에도 동일하게 적용되었습니다.

## 질문 및 이외 사항

- NOT IN 구문이 성능이 좋지 않다는 의견을 들어, 추후 개선해보도록 하겠습니다!

## 이슈 번호

- close #184 