### PR TITLE
[Feat]auth apple api

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/member/Member.java
+++ b/src/main/java/com/example/dgbackend/domain/member/Member.java
@@ -63,6 +63,7 @@ public class Member extends BaseTimeEntity {
     private String drinkingTimes; // 음주 횟수
 
 
+
     //주류 추천 정보 관련 setter
     /*
     Setter: preferredAlcoholType (선호 주종)

--- a/src/main/java/com/example/dgbackend/global/jwt/controller/JwtController.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/controller/JwtController.java
@@ -39,6 +39,12 @@ public class JwtController {
         return ApiResponse.onSuccess(authService.loginOrJoin(response, authRequest));
     }
 
+    @PostMapping("/apple")
+    public ApiResponse<AuthResponse> appleLoign(@RequestBody AuthRequest authRequest,
+        HttpServletResponse response) throws IOException {
+        return ApiResponse.onSuccess(authService.loginOrJoin(response, authRequest));
+    }
+
     @PostMapping("/naver")
     public ApiResponse<AuthResponse> naverLoign(@RequestBody AuthRequest authRequest,
         HttpServletResponse response) throws IOException {

--- a/src/main/java/com/example/dgbackend/global/jwt/service/AuthService.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/service/AuthService.java
@@ -57,6 +57,7 @@ public class AuthService {
             response.addHeader("newMember", "true");
         } else {
             memberId = loginMember.get().getId();
+            response.addHeader("newMember", "false");
 
             if (loginMember.get().getState() == State.REPORTED) {
                 throw new ApiException(ErrorStatus._PERMANENTLY_REPORTED_MEMBER);

--- a/src/main/java/com/example/dgbackend/global/jwt/service/AuthService.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/service/AuthService.java
@@ -53,6 +53,8 @@ public class AuthService {
             Member newMember = MemberRequest.toEntity(authRequest);
             memberCommandService.saveMember(newMember);
             memberId = newMember.getId();
+
+            response.addHeader("newMember", "true");
         } else {
             memberId = loginMember.get().getId();
 


### PR DESCRIPTION
## 요약
- Apple소셜로그인 api구현
- 로그인/가입시 헤더의 newMember변수에 true/false로 표시합니다.


## 상세 내용
![IMG_6843](https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/32007781/08e47210-7b08-4c8c-bc53-3c7953da9f15)

-

## 질문 및 이외 사항

-

## 이슈 번호

-