### PR TITLE
fix: 회원가입 시 중복 닉네임 거르기

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/member/repository/MemberRepository.java
@@ -16,4 +16,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByProviderAndProviderId(String provider, String providerId);
 
     Optional<Member> findMemberById(Long id);
+
+    Boolean existsByNickName(String nickName);
 }

--- a/src/main/java/com/example/dgbackend/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/member/service/MemberQueryService.java
@@ -6,5 +6,7 @@ import java.util.Optional;
 public interface MemberQueryService {
     Boolean existsByProviderAndProviderId(String provider, String providerId);
 
+    Boolean existsByNickname(String nickname);
+
     Optional<Member> findByProviderAndProviderId(String provider, String providerId);
 }

--- a/src/main/java/com/example/dgbackend/domain/member/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/member/service/MemberQueryServiceImpl.java
@@ -20,6 +20,11 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     }
 
     @Override
+    public Boolean existsByNickname(String nickname) {
+        return memberRepository.existsByNickName(nickname);
+    }
+
+    @Override
     public Optional<Member> findByProviderAndProviderId(String provider, String providerId) {
         return memberRepository.findByProviderAndProviderId(provider, providerId);
     }

--- a/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
@@ -20,6 +20,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN_MEMBER_REQUEST(HttpStatus.FORBIDDEN, "MEMBER_002", "해당 사용자는 금지된 요청을 하였습니다."),
     _PERMANENTLY_REPORTED_MEMBER(HttpStatus.FORBIDDEN, "MEMBER_003", "해당 사용자는 영구 정지되었습니다."),
     _TEMPORARILY_REPORTED_MEMBER(HttpStatus.FORBIDDEN, "MEMBER_004", "해당 사용자는 일시 정지되었습니다."),
+    _DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "MEMBER_005", "해당 닉네임은 중복된 닉네임입니다."),
 
     //오늘의 조합 관련
     _COMBINATION_NOT_FOUND(HttpStatus.NOT_FOUND, "COMBINATION_001", "존재하지 않는 오늘의 조합입니다."),

--- a/src/main/java/com/example/dgbackend/global/jwt/service/AuthService.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/service/AuthService.java
@@ -50,6 +50,9 @@ public class AuthService {
             authRequest.getProviderId());
 
         if (loginMember.isEmpty()) {
+            if (memberQueryService.existsByNickname(authRequest.getNickName())) {
+                throw new ApiException(ErrorStatus._DUPLICATE_NICKNAME);
+            }
             Member newMember = MemberRequest.toEntity(authRequest);
             memberCommandService.saveMember(newMember);
             memberId = newMember.getId();


### PR DESCRIPTION
## 요약

- 회원가입 시 중복 닉네임 거르기

## 상세 내용

- 닉네임이 동일할 경우 API 예외처리 
<img width="1423" alt="스크린샷 2024-07-01 오후 6 43 13" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/101540728/202891ce-5232-47d7-8dde-dd6546e6f0e9">

## 질문 및 이외 사항

-

## 이슈 번호

- #195 