### PR TITLE
change: newMember 전달 방식 변경

### DIFF
--- a/src/main/java/com/example/dgbackend/global/jwt/dto/AuthResponse.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/dto/AuthResponse.java
@@ -15,14 +15,16 @@ public class AuthResponse {
     private String provider;
     private String nickName;
     private Long memberId;
+    private boolean newMember;
     private LocalDateTime createdAt;
 
-    public static AuthResponse toAuthResponse(String provider, String nickName, Long memberId) {
+    public static AuthResponse toAuthResponse(String provider, String nickName, boolean newMember, Long memberId) {
 
         return AuthResponse.builder()
             .provider(provider)
             .nickName(nickName)
             .memberId(memberId)
+            .newMember(newMember)
             .createdAt(LocalDateTime.now())
             .build();
     }

--- a/src/main/java/com/example/dgbackend/global/jwt/service/AuthService.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/service/AuthService.java
@@ -49,6 +49,8 @@ public class AuthService {
             authRequest.getProvider(),
             authRequest.getProviderId());
 
+        boolean isNewMember = true;
+
         if (loginMember.isEmpty()) {
             if (memberQueryService.existsByNickname(authRequest.getNickName())) {
                 throw new ApiException(ErrorStatus._DUPLICATE_NICKNAME);
@@ -57,10 +59,9 @@ public class AuthService {
             memberCommandService.saveMember(newMember);
             memberId = newMember.getId();
 
-            response.addHeader("newMember", "true");
         } else {
             memberId = loginMember.get().getId();
-            response.addHeader("newMember", "false");
+            isNewMember = false;
 
             if (loginMember.get().getState() == State.REPORTED) {
                 throw new ApiException(ErrorStatus._PERMANENTLY_REPORTED_MEMBER);
@@ -74,7 +75,7 @@ public class AuthService {
         registerHeaderToken(response, id, "Authorization");
         registerHeaderToken(response, id, "RefreshToken");
 
-        return AuthResponse.toAuthResponse(authRequest.getProvider(), authRequest.getNickName(),
+        return AuthResponse.toAuthResponse(authRequest.getProvider(), authRequest.getNickName(),isNewMember,
             memberId);
 
     }


### PR DESCRIPTION
## 요약

- 헤더에서 전달하던 newMember변수를 헤더에서 제거하였습니다.
- newMember변수를 responseBody로 전달하도록 수정하였습니다.
- 새로운 유저는 true, 기존 유저는 false를 반환합니다.

## 상세 내용
- 이미 존재하는 유저
<img width="1087" alt="스크린샷 2024-07-02 오후 7 58 46" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/32007781/78386d9e-fd1a-4b21-801d-97cbecfff006">
- 새로운 유저
<img width="1073" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-BackEnd/assets/32007781/2ee2dac5-faa4-4827-91ec-8990d516802f">


## 질문 및 이외 사항

-

## 이슈 번호

- #200 