### PR TITLE
fix: 프론트엔드 요구사항 반영

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeQueryServiceImpl.java
@@ -58,9 +58,9 @@ public class CombinationLikeQueryServiceImpl implements CombinationLikeQueryServ
     @Override
     public Optional<CombinationLike> getCombinationLikeEntity(Member member, Long combinationId) {
 
-        Member memberByName = memberService.findMemberByName(member.getName());
+        Member memberById = memberService.findMemberById(member.getId());
 
         return combinationLikeRepository.findByCombinationAndMember(
-            getCombinationEntity(combinationId), memberByName);
+            getCombinationEntity(combinationId), memberById);
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/member/dto/MemberResponse.java
@@ -39,6 +39,7 @@ public class MemberResponse {
         String birthDate;
         String profileImageUrl;
         String phoneNumber;
+        String provider;
     }
 
     public static GetMember toGetMember(Member member) {
@@ -50,6 +51,7 @@ public class MemberResponse {
                 .birthDate(member.getBirthDate())
                 .profileImageUrl(member.getProfileImageUrl())
                 .phoneNumber(member.getPhoneNumber())
+                .provider(member.getProvider())
                 .build();
     }
 

--- a/src/main/java/com/example/dgbackend/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/member/service/MemberCommandServiceImpl.java
@@ -24,9 +24,6 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     MemberRepository memberRepository;
 
     private final S3Service s3Service;
-    private final CombinationCommandService combinationCommandService;
-    private final CombinationCommentCommandService combinationCommentCommandService;
-    private final CombinationLikeCommandService combinationLikeCommandService;
 
     @Override
     public MemberResponse.RecommendInfoDTO patchRecommendInfo(Member member,

--- a/src/main/java/com/example/dgbackend/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/dgbackend/domain/member/service/MemberService.java
@@ -18,4 +18,9 @@ public class MemberService {
                 .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_MEMBER));
     }
 
+    public Member findMemberById(Long id) {
+        return memberRepository.findMemberById(id)
+                .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_MEMBER));
+    }
+
 }


### PR DESCRIPTION
## 요약

- 프론트엔드 요구사항 반영 

## 상세 내용

- 멤버 정보 조회 시 Reponse Body에 Provider 값 추가하여 전송
- 오늘의 조합 좋아요 로직 변경
  - 기존 멤버를 name으로 찾아오는 쿼리 대신 id로 찾아오는 쿼리로 변경 

## 질문 및 이외 사항

-

## 이슈 번호

- #203 