### PR TITLE
Fix: 좋아요한 게시글 목록 차단 적용

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
@@ -26,7 +26,7 @@ public interface CombinationRepository extends JpaRepository<Combination, Long> 
 	Page<Combination> findCombinationsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
 		Long likeCount, PageRequest pageRequest, Long memberId);
 
-	@Query("SELECT cl.combination FROM CombinationLike cl WHERE cl.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND cl.member.id = :memberId AND cl.combination.state = true AND cl.state = true")
+	@Query("SELECT cl.combination FROM CombinationLike cl WHERE cl.combination.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND cl.member.id = :memberId AND cl.combination.state = true AND cl.state = true")
 	Page<Combination> findCombinationsByMemberIdAndStateIsTrue(Long memberId,
 		PageRequest pageRequest);
 

--- a/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
@@ -26,7 +26,7 @@ public interface CombinationRepository extends JpaRepository<Combination, Long> 
 	Page<Combination> findCombinationsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
 		Long likeCount, PageRequest pageRequest, Long memberId);
 
-	@Query("SELECT cl.combination FROM CombinationLike cl WHERE cl.member.id = :memberId AND cl.combination.state = true AND cl.state = true")
+	@Query("SELECT cl.combination FROM CombinationLike cl WHERE cl.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND cl.member.id = :memberId AND cl.combination.state = true AND cl.state = true")
 	Page<Combination> findCombinationsByMemberIdAndStateIsTrue(Long memberId,
 		PageRequest pageRequest);
 

--- a/src/main/java/com/example/dgbackend/domain/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/repository/RecipeRepository.java
@@ -18,7 +18,7 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
     Page<Recipe> findAllByMemberIdAndStateIsTrueOrderByCreatedAtDesc(Long memberId, PageRequest pageRequest);
 
-    @Query("SELECT rl.recipe FROM RecipeLike rl WHERE rl.member.id = :memberId AND rl.recipe.state = true AND rl.state = true")
+    @Query("SELECT rl.recipe FROM RecipeLike rl WHERE rl.member.id = :memberId AND rl.recipe.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND rl.recipe.state = true AND rl.state = true")
     Page<Recipe> findRecipesByMemberIdAndStateIsTrue(Long memberId, PageRequest pageRequest);
 
     @Query("SELECT r FROM Recipe r WHERE r.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND r.title LIKE %:keyword% AND r.state = true ORDER BY r.createdAt DESC")


### PR DESCRIPTION
## 요약

- 좋아요한 게시글 목록에서 차단을 적용합니다.

## 상세 내용

- 오늘의 조합 좋아요한 게시글 목록 API 차단을 적용했습니다.
- 레시피 좋아요한 게시글 목록 API 차단을 적용했습니다.

## 질문 및 이외 사항

-

## 이슈 번호

- close #210 