### PR TITLE
Feat: 레시피 리팩토링 및 멤버 검증 기능 구현

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/controller/RecipeController.java
@@ -33,11 +33,8 @@ public class RecipeController {
     private final RecipeServiceImpl recipeServiceImpl;
     private final RecipeScheduler recipeScheduler;
 
-    //TODO: @AutenticationPrincipal로 변경
-
-
     @Operation(summary = "모든 레시피북 조회", description = "삭제되지 않은 레시피북 목록을 조회합니다.")
-    @Parameter(name = "page", description = "페이지 번호, Query Param 입니다.", required = true, example = "0s", in = ParameterIn.QUERY)
+    @Parameter(name = "page", description = "페이지 번호, Query Param 입니다.", required = true, example = "0", in = ParameterIn.QUERY)
     @GetMapping
     public ApiResponse<RecipeResponse.RecipeResponseList> getRecipes(@RequestParam("page") int page,
                                                                      @MemberObject Member member) {

--- a/src/main/java/com/example/dgbackend/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/controller/RecipeController.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,77 +29,81 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class RecipeController {
 
-    private final RecipeServiceImpl recipeServiceImpl;
-    private final RecipeScheduler recipeScheduler;
+	private final RecipeServiceImpl recipeServiceImpl;
+	private final RecipeScheduler recipeScheduler;
 
-    @Operation(summary = "모든 레시피북 조회", description = "삭제되지 않은 레시피북 목록을 조회합니다.")
-    @Parameter(name = "page", description = "페이지 번호, Query Param 입니다.", required = true, example = "0", in = ParameterIn.QUERY)
-    @GetMapping
-    public ApiResponse<RecipeResponse.RecipeResponseList> getRecipes(@RequestParam("page") int page,
-                                                                     @MemberObject Member member) {
-        return ApiResponse.onSuccess(recipeServiceImpl.getExistRecipes(page, member));
-    }
+	@Operation(summary = "모든 레시피북 조회", description = "삭제되지 않은 레시피북 목록을 조회합니다.")
+	@Parameter(name = "page", description = "페이지 번호, Query Param 입니다.", required = true, example = "0", in = ParameterIn.QUERY)
+	@GetMapping
+	public ApiResponse<RecipeResponse.RecipeResponseList> getRecipes(@RequestParam("page") int page,
+		@Parameter(hidden = true) @MemberObject Member loginMember) {
+		return ApiResponse.onSuccess(recipeServiceImpl.getExistRecipes(page, loginMember));
+	}
 
-    @Operation(summary = "레시피북 상세정보 조회", description = "특정 레시피북 정보를 조회합니다.")
-    @Parameter(name = "recipeId", description = "레시피북 Id, Path Variable 입니다.", required = true, example = "1", in = ParameterIn.PATH)
-    @GetMapping("/{recipeId}")
-    public ApiResponse<RecipeResponse> getRecipe(@PathVariable Long recipeId,
-                                                 @MemberObject Member member) {
-        return ApiResponse.onSuccess(recipeServiceImpl.getRecipeDetail(recipeId, member));
-    }
+	@Operation(summary = "레시피북 상세정보 조회", description = "특정 레시피북 정보를 조회합니다.")
+	@Parameter(name = "recipeId", description = "레시피북 Id, Path Variable 입니다.", required = true, example = "1", in = ParameterIn.PATH)
+	@GetMapping("/{recipeId}")
+	public ApiResponse<RecipeResponse> getRecipe(@PathVariable Long recipeId,
+		@Parameter(hidden = true) @MemberObject Member loginMember) {
+		return ApiResponse.onSuccess(recipeServiceImpl.getRecipeDetail(recipeId, loginMember));
+	}
 
-    @Operation(summary = "레시피북 등록", description = "레시피북을 등록합니다.")
-    @PostMapping
-    public ApiResponse<RecipeResponse> createRecipe(@MemberObject Member member,
-        @RequestBody RecipeRequest recipeRequest) {
-        return ApiResponse.onSuccess(recipeServiceImpl.createRecipe(recipeRequest, member));
-    }
+	@Operation(summary = "레시피북 등록", description = "레시피북을 등록합니다.")
+	@PostMapping
+	public ApiResponse<RecipeResponse> createRecipe(@RequestBody RecipeRequest recipeRequest,
+		@Parameter(hidden = true) @MemberObject Member loginMember) {
+		return ApiResponse.onSuccess(recipeServiceImpl.createRecipe(recipeRequest, loginMember));
+	}
 
-    @Operation(summary = "레시피북 수정", description = "레시피북을 수정합니다.")
-    @Parameter(name = "recipeId", description = "레시피북 Id, Path Variable 입니다.", required = true, example = "1", in = ParameterIn.PATH)
-    @PatchMapping("/{recipeId}")
-    public ApiResponse<RecipeResponse> updateRecipe(@PathVariable Long recipeId,
-        @RequestBody RecipeRequest recipeRequest) {
-        return ApiResponse.onSuccess(recipeServiceImpl.updateRecipe(recipeId, recipeRequest));
-    }
+	@Operation(summary = "레시피북 수정", description = "레시피북을 수정합니다.")
+	@Parameter(name = "recipeId", description = "레시피북 Id, Path Variable 입니다.", required = true, example = "1", in = ParameterIn.PATH)
+	@PatchMapping("/{recipeId}")
+	public ApiResponse<RecipeResponse> updateRecipe(@PathVariable Long recipeId,
+		@RequestBody RecipeRequest recipeRequest,
+		@Parameter(hidden = true) @MemberObject Member loginMember) {
+		return ApiResponse.onSuccess(
+			recipeServiceImpl.updateRecipe(recipeId, recipeRequest, loginMember));
+	}
 
-    @Operation(summary = "레시피북 삭제", description = "레시피북을 삭제합니다.")
-    @Parameter(name = "recipeId", description = "레시피북 Id, Path Variable 입니다.", required = true, example = "1", in = ParameterIn.PATH)
-    @DeleteMapping("/{recipeId}")
-    public ApiResponse<String> deleteRecipe(@PathVariable Long recipeId) {
-        recipeServiceImpl.deleteRecipe(recipeId);
-        return ApiResponse.onSuccess("삭제 완료");
-    }
+	@Operation(summary = "레시피북 삭제", description = "레시피북을 삭제합니다.")
+	@Parameter(name = "recipeId", description = "레시피북 Id, Path Variable 입니다.", required = true, example = "1", in = ParameterIn.PATH)
+	@DeleteMapping("/{recipeId}")
+	public ApiResponse<String> deleteRecipe(@PathVariable Long recipeId,
+		@Parameter(hidden = true) @MemberObject Member loginMember) {
+		return ApiResponse.onSuccess(recipeServiceImpl.deleteRecipe(recipeId, loginMember));
+	}
 
-    @Operation(summary = "내가 작성한 레시피북 조회", description = "특정 회원의 레시피북 목록을 조회합니다.")
-    @Parameter(name = "page", description = "내가 작성한 레시피북 목록 페이지 번호, query string 입니다.")
-    @GetMapping("/my-page")
-    public ApiResponse<RecipeResponse.RecipeMyPageList> getMyPageList(
-        @MemberObject Member member, @CheckPage @RequestParam(name= "page" ) Integer page) {
-        return ApiResponse.onSuccess(recipeServiceImpl.getRecipeMyPageList(member, page));
-    }
+	@Operation(summary = "내가 작성한 레시피북 조회", description = "특정 회원의 레시피북 목록을 조회합니다.")
+	@Parameter(name = "page", description = "내가 작성한 레시피북 목록 페이지 번호, query string 입니다.")
+	@GetMapping("/my-page")
+	public ApiResponse<RecipeResponse.RecipeMyPageList> getMyPageList(
+		@Parameter(hidden = true) @MemberObject Member loginMember,
+		@CheckPage @RequestParam(name = "page") Integer page) {
+		return ApiResponse.onSuccess(recipeServiceImpl.getRecipeMyPageList(loginMember, page));
+	}
 
-    @Operation(summary = "내가 좋아요한 레시피북 조회", description = "좋아요를 누른 레시피북 목록을 조회합니다.")
-    @Parameter(name = "page", description = "내가 좋아요한 목록 페이지 번호, query string 입니다.")
-    @GetMapping("/likes")
-    public ApiResponse<RecipeResponse.RecipeMyPageList> getLikeList(
-        @MemberObject Member member, @CheckPage @RequestParam(name = "page") Integer page) {
-        return ApiResponse.onSuccess(recipeServiceImpl.getRecipeLikeList(member, page));
-    }
+	@Operation(summary = "내가 좋아요한 레시피북 조회", description = "좋아요를 누른 레시피북 목록을 조회합니다.")
+	@Parameter(name = "page", description = "내가 좋아요한 목록 페이지 번호, query string 입니다.")
+	@GetMapping("/likes")
+	public ApiResponse<RecipeResponse.RecipeMyPageList> getLikeList(
+		@Parameter(hidden = true) @MemberObject Member loginMember,
+		@CheckPage @RequestParam(name = "page") Integer page) {
+		return ApiResponse.onSuccess(recipeServiceImpl.getRecipeLikeList(loginMember, page));
+	}
 
-    @Operation(summary = "레시피북 검색", description = "레시피북 목록을 검색합니다.")
-    @GetMapping("/search")
-    public ApiResponse<RecipeResponse.RecipeResponseList> findRecipesByKeyword(
-        @RequestParam(value = "page") Integer page,
-        @RequestParam(value = "keyword") String keyword,
-        @MemberObject Member member) {
-        return ApiResponse.onSuccess(recipeServiceImpl.findRecipesByKeyword(page, keyword, member));
-    }
+	@Operation(summary = "레시피북 검색", description = "레시피북 목록을 검색합니다.")
+	@GetMapping("/search")
+	public ApiResponse<RecipeResponse.RecipeResponseList> findRecipesByKeyword(
+		@RequestParam(value = "page") Integer page, @RequestParam(value = "keyword") String keyword,
+		@Parameter(hidden = true) @MemberObject Member loginMember) {
+		return ApiResponse.onSuccess(
+			recipeServiceImpl.findRecipesByKeyword(page, keyword, loginMember));
+	}
 
-    @Operation(summary = "메인 레시피북 조회", description = "메인에 띄울 레시피북을 조회합니다.")
-    @GetMapping("/main")
-    public ApiResponse<RecipeResponse.RecipeMainList> getMainRecipeList() {
-        return ApiResponse.onSuccess(recipeScheduler.getMainTodayRecipeList());
-    }
+	@Operation(summary = "메인 레시피북 조회", description = "메인에 띄울 레시피북을 조회합니다.")
+	@GetMapping("/main")
+	public ApiResponse<RecipeResponse.RecipeMainList> getMainRecipeList() {
+		return ApiResponse.onSuccess(recipeScheduler.getMainTodayRecipeList());
+	}
 }
 

--- a/src/main/java/com/example/dgbackend/domain/recipe/dto/RecipeRequest.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/dto/RecipeRequest.java
@@ -40,7 +40,7 @@ public class RecipeRequest {
     @Schema(description = "추천 조합", example = "김치찌개와 참이슬")
     private String recommendCombination;
 
-    @Schema(description = "해시태그 리스트", example = "[김치찌개, 참이슬]")
+    @Schema(description = "해시태그 리스트", example = "[\"김치찌개\", \"참이슬\"]")
     private List<String> hashTagNameList;
 
     public static Recipe toEntity(RecipeRequest recipeRequest, Member member) {

--- a/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeService.java
@@ -4,34 +4,34 @@ import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.recipe.Recipe;
 import com.example.dgbackend.domain.recipe.dto.RecipeRequest;
 import com.example.dgbackend.domain.recipe.dto.RecipeResponse;
-import java.util.List;
 
 public interface RecipeService {
 
-    RecipeResponse.RecipeResponseList getExistRecipes(int page, Member member);
+	RecipeResponse.RecipeResponseList getExistRecipes(int page, Member loginMember);
 
-    RecipeResponse getRecipeDetail(Long id, Member member);
+	RecipeResponse getRecipeDetail(Long id, Member member);
 
-    RecipeResponse createRecipe(RecipeRequest recipeRequest, Member member);
+	RecipeResponse createRecipe(RecipeRequest recipeRequest, Member loginMember);
 
-    RecipeResponse updateRecipe(Long id, RecipeRequest recipeRequest);
+	RecipeResponse updateRecipe(Long id, RecipeRequest recipeRequest, Member loginMember);
 
-    void deleteRecipe(Long id);
+	String deleteRecipe(Long id, Member loginMember);
 
-    //레시피 이름과 회원 이름으로 레시피 탐색
-    Recipe getRecipe(Long id);
+	//레시피 이름과 회원 이름으로 레시피 탐색
+	Recipe getRecipe(Long id);
 
-    //레시피가 삭제된 경우 예외처리
-    Recipe isDelete(Recipe recipe);
+	//레시피가 삭제된 경우 예외처리
+	Recipe isDelete(Recipe recipe);
 
-    void isAlreadyCreate(String RecipeName, String memberName);
+	void isAlreadyCreate(String RecipeName, String memberName);
 
-    RecipeResponse.RecipeMyPageList getRecipeMyPageList(Member member, Integer Page);
+	RecipeResponse.RecipeMyPageList getRecipeMyPageList(Member loginMember, Integer Page);
 
-    RecipeResponse.RecipeMyPageList getRecipeLikeList(Member member, Integer Page);
+	RecipeResponse.RecipeMyPageList getRecipeLikeList(Member loginMember, Integer Page);
 
-    RecipeResponse.RecipeResponseList findRecipesByKeyword(Integer page, String keyword, Member member);
+	RecipeResponse.RecipeResponseList findRecipesByKeyword(Integer page, String keyword,
+		Member loginMember);
 
-    RecipeResponse getRecipeDetailResponse(Recipe recipes, Member member);
+	RecipeResponse getRecipeDetailResponse(Recipe recipes, Member loginMember);
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.dgbackend.domain.recipe.service;
 
 import static com.example.dgbackend.domain.recipe.dto.RecipeResponse.toRecipeMyPageList;
+import static com.example.dgbackend.global.common.MemberValidator.isMatch;
 
 import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.recipe.Recipe;
@@ -27,138 +28,155 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class RecipeServiceImpl implements RecipeService {
 
-    private final RecipeRepository recipeRepository;
-    private final RecipeHashTagService recipeHashTagService;
-    private final RecipeLikeService recipeLikeService;
+	private final RecipeRepository recipeRepository;
+	private final RecipeHashTagService recipeHashTagService;
+	private final RecipeLikeService recipeLikeService;
 
-    @Override
-    public RecipeResponse.RecipeResponseList getExistRecipes(int page, Member member) {
-        Pageable pageable = Pageable.ofSize(10).withPage(page);
+	@Override
+	public RecipeResponse.RecipeResponseList getExistRecipes(int page, Member member) {
+		Pageable pageable = Pageable.ofSize(10).withPage(page);
 
-        Page<Recipe> allByState = recipeRepository.findAllByStateOrderByCreatedAtDesc(true, pageable, member.getId());
+		Page<Recipe> allByState = recipeRepository.findAllByStateOrderByCreatedAtDesc(true,
+			pageable, member.getId());
 
-        List<RecipeResponse> recipeResponseList = allByState.getContent().stream()
-                .map(recipe -> {
-                    return getRecipeDetailResponse(recipe, member);
-                }).toList();
+		List<RecipeResponse> recipeResponseList = allByState.getContent().stream()
+			.map(recipe -> {
+				return getRecipeDetailResponse(recipe, member);
+			}).toList();
 
-        return RecipeResponse.toRecipeResponseList(allByState, recipeResponseList);
-    }
+		return RecipeResponse.toRecipeResponseList(allByState, recipeResponseList);
+	}
 
-    @Override
-    public RecipeResponse getRecipeDetail(Long id, Member member) {
-        Recipe recipe = getRecipe(id);
+	@Override
+	public RecipeResponse getRecipeDetail(Long id, Member member) {
+		Recipe recipe = getRecipe(id);
 		isBlocked(id, member.getId());
-        return getRecipeDetailResponse(recipe, member);
-    }
+		return getRecipeDetailResponse(recipe, member);
+	}
 
-    //like 상태를 추가 (좋아요 누른 상태인지 확인)
-    @Override
-    public RecipeResponse getRecipeDetailResponse(Recipe recipes, Member member) {
+	//like 상태를 추가 (좋아요 누른 상태인지 확인)
+	@Override
+	public RecipeResponse getRecipeDetailResponse(Recipe recipes, Member member) {
 
-        boolean state = recipeLikeService.getRecipeLike(recipes.getId(), member).isState();
+		boolean state = recipeLikeService.getRecipeLike(recipes.getId(), member).isState();
 
-        return RecipeResponse.toResponse(recipes, state);
-    }
+		return RecipeResponse.toResponse(recipes, state);
+	}
 
-    @Override
-    @Transactional
-    public RecipeResponse createRecipe(RecipeRequest recipeRequest, Member memberEntity) {
+	@Override
+	@Transactional
+	public RecipeResponse createRecipe(RecipeRequest recipeRequest, Member loginMember) {
 
+		//레시피 저장
+		Recipe save = recipeRepository.save(RecipeRequest.toEntity(recipeRequest, loginMember));
 
-        //레시피 저장
-        Recipe save = recipeRepository.save(RecipeRequest.toEntity(recipeRequest, memberEntity));
+		//해시태그 저장
+		List<RecipeHashTag> hashTags = recipeHashTagService.uploadRecipeHashTag(save,
+			recipeRequest.getHashTagNameList());
 
-        //해시태그 저장
-        List<RecipeHashTag> hashTags = recipeHashTagService.uploadRecipeHashTag(save, recipeRequest.getHashTagNameList());
+		//레시피에 해시태그 저장
+		save.setHashTagList(hashTags);
 
-        //레시피에 해시태그 저장
-        save.setHashTagList(hashTags);
+		return getRecipeDetailResponse(save, loginMember);
+	}
 
-        return getRecipeDetailResponse(save, memberEntity);
-    }
+	@Override
+	@Transactional
+	public RecipeResponse updateRecipe(Long id, RecipeRequest recipeRequest, Member loginMember) {
+		Recipe recipe = getRecipe(id);
 
-    @Override
-    @Transactional
-    public RecipeResponse updateRecipe(Long id, RecipeRequest recipeRequest) {
-        Recipe recipe = getRecipe(id);
+		if (isMatch(loginMember, recipe.getMember())) {
+			//해시태그 저장
+			List<RecipeHashTag> hashTags = recipeHashTagService.uploadRecipeHashTag(recipe,
+				recipeRequest.getHashTagNameList());
+			recipe.setHashTagList(hashTags);
+			return getRecipeDetailResponse(recipe.update(recipeRequest), recipe.getMember());
+		} else {
+			throw new ApiException(ErrorStatus._INVALID_MEMBER);
+		}
+	}
 
-        //해시태그 저장
-        List<RecipeHashTag> hashTags = recipeHashTagService.uploadRecipeHashTag(recipe, recipeRequest.getHashTagNameList());
-        recipe.setHashTagList(hashTags);
-        return getRecipeDetailResponse(recipe.update(recipeRequest), recipe.getMember());
-    }
+	@Override
+	@Transactional
+	public String deleteRecipe(Long id, Member loginMember) {
+		Recipe recipe = getRecipe(id);
 
-    @Override
-    @Transactional
-    public void deleteRecipe(Long id) {
-        getRecipe(id).delete();
-        recipeHashTagService.deleteRecipeHashTag(id);
-    }
+		if (isMatch(loginMember, recipe.getMember())) {
+			recipe.delete();
+			recipeHashTagService.deleteRecipeHashTag(id);
+			return "삭제 완료";
+		} else {
+			throw new ApiException(ErrorStatus._INVALID_MEMBER);
+		}
+	}
 
-    //레시피 이름과 회원 이름으로 레시피 탐색
-    @Override
-    public Recipe getRecipe(Long id) {
+	//레시피 이름과 회원 이름으로 레시피 탐색
+	@Override
+	public Recipe getRecipe(Long id) {
 
-        Recipe recipe = recipeRepository.findById(id)
-                .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE));
+		Recipe recipe = recipeRepository.findById(id)
+			.orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE));
 
-        return isDelete(recipe);
-    }
+		return isDelete(recipe);
+	}
 
-    //레시피가 삭제된 경우 예외처리
-    @Override
-    public Recipe isDelete(Recipe recipe) {
+	//레시피가 삭제된 경우 예외처리
+	@Override
+	public Recipe isDelete(Recipe recipe) {
 
-        if (!recipe.isState()) {
-            throw new ApiException(ErrorStatus._DELETE_RECIPE);
-        }
+		if (!recipe.isState()) {
+			throw new ApiException(ErrorStatus._DELETE_RECIPE);
+		}
 
-        return recipe;
-    }
+		return recipe;
+	}
 
-    @Override
-    public void isAlreadyCreate(String RecipeName, String memberName) {
+	@Override
+	public void isAlreadyCreate(String RecipeName, String memberName) {
 
-        recipeRepository.findAllByTitleAndMember_Name(RecipeName, memberName).stream()
-                .filter(Recipe::isState)
-                .findFirst()
-                .ifPresent(recipe -> {
-                    throw new ApiException(ErrorStatus._ALREADY_CREATE_RECIPE);
-                });
-    }
+		recipeRepository.findAllByTitleAndMember_Name(RecipeName, memberName).stream()
+			.filter(Recipe::isState)
+			.findFirst()
+			.ifPresent(recipe -> {
+				throw new ApiException(ErrorStatus._ALREADY_CREATE_RECIPE);
+			});
+	}
 
-    @Override
-    public RecipeResponse.RecipeResponseList findRecipesByKeyword(Integer page, String keyword, Member member) {
+	@Override
+	public RecipeResponse.RecipeResponseList findRecipesByKeyword(Integer page, String keyword,
+		Member member) {
 
-        Pageable pageable = Pageable.ofSize(10).withPage(page);
+		Pageable pageable = Pageable.ofSize(10).withPage(page);
 
-        Page<Recipe> recipesByKeyword = recipeRepository.findRecipesByTitleContainingAndStateIsTrueOrderByCreatedAtDesc(keyword, pageable,
+		Page<Recipe> recipesByKeyword = recipeRepository.findRecipesByTitleContainingAndStateIsTrueOrderByCreatedAtDesc(
+			keyword, pageable,
 			member.getId());
 
-        List<RecipeResponse> recipeResponseList = recipesByKeyword.getContent().stream()
-                .map(recipe -> {
-                    return getRecipeDetailResponse(recipe, member);
-                }).toList();
+		List<RecipeResponse> recipeResponseList = recipesByKeyword.getContent().stream()
+			.map(recipe -> {
+				return getRecipeDetailResponse(recipe, member);
+			}).toList();
 
-        return RecipeResponse.toRecipeResponseList(recipesByKeyword, recipeResponseList);
-    }
+		return RecipeResponse.toRecipeResponseList(recipesByKeyword, recipeResponseList);
+	}
 
-    @Override
-    public RecipeResponse.RecipeMyPageList getRecipeMyPageList(Member member,
-                                                               Integer page) {
-        Page<Recipe> recipePage = recipeRepository.findAllByMemberIdAndStateIsTrueOrderByCreatedAtDesc(member.getId(), PageRequest.of(page, 21));
+	@Override
+	public RecipeResponse.RecipeMyPageList getRecipeMyPageList(Member member,
+		Integer page) {
+		Page<Recipe> recipePage = recipeRepository.findAllByMemberIdAndStateIsTrueOrderByCreatedAtDesc(
+			member.getId(), PageRequest.of(page, 21));
 
-        return toRecipeMyPageList(recipePage);
-    }
+		return toRecipeMyPageList(recipePage);
+	}
 
-    @Override
-    public RecipeResponse.RecipeMyPageList getRecipeLikeList(Member member,
-                                                             Integer page) {
-        Page<Recipe> recipePage = recipeRepository.findRecipesByMemberIdAndStateIsTrue(member.getId(), PageRequest.of(page, 21));
+	@Override
+	public RecipeResponse.RecipeMyPageList getRecipeLikeList(Member member,
+		Integer page) {
+		Page<Recipe> recipePage = recipeRepository.findRecipesByMemberIdAndStateIsTrue(
+			member.getId(), PageRequest.of(page, 21));
 
-        return toRecipeMyPageList(recipePage);
-    }
+		return toRecipeMyPageList(recipePage);
+	}
 
 	private void isBlocked(Long recipeId, Long memberId) {
 		Recipe blockedRecipe = recipeRepository.findByIdAndMemberAndStateIsTrue(recipeId, memberId)

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/controller/RecipeCommentController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/controller/RecipeCommentController.java
@@ -1,7 +1,6 @@
 package com.example.dgbackend.domain.recipecomment.controller;
 
 import com.example.dgbackend.domain.member.Member;
-import com.example.dgbackend.domain.member.repository.MemberRepository;
 import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentRequest;
 import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentResponse;
 import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentVO;
@@ -13,9 +12,15 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "레시피북 댓글 API")
 @RestController
@@ -25,8 +30,6 @@ public class RecipeCommentController {
 
 	private final RecipeCommentServiceImpl recipeCommentService;
 
-	private final MemberRepository memberRepository;
-
 	@Operation(summary = "레시피북 댓글 조회", description = "특정 레시피북의 댓글을 조회합니다.")
 	@Parameter(name = "recipeId", description = "레시피북 Id, Path Variable 입니다.", required = true, example = "1", in = ParameterIn.PATH)
 	@Parameter(name = "page", description = "페이지 번호, Query Param 입니다.", required = true, example = "0", in = ParameterIn.QUERY)
@@ -34,7 +37,8 @@ public class RecipeCommentController {
 	public ApiResponse<RecipeCommentResponse.RecipeCommentResponseList> getRecipeComments(
 		@PathVariable Long recipeId, @RequestParam("page") int page,
 		@Parameter(hidden = true) @MemberObject Member loginMember) {
-		return ApiResponse.onSuccess(recipeCommentService.getRecipeComment(recipeId, page, loginMember));
+		return ApiResponse.onSuccess(
+			recipeCommentService.getRecipeComment(recipeId, page, loginMember));
 	}
 
 	@Operation(summary = "레시피북 댓글 등록", description = "레시피북 댓글을 등록합니다.")
@@ -42,26 +46,29 @@ public class RecipeCommentController {
 	@PostMapping("/{recipeId}")
 	public ApiResponse<RecipeCommentResponse> saveRecipeComment(@PathVariable Long recipeId,
 		@RequestBody RecipeCommentRequest.Post recipeCommentRequest,
-		@MemberObject Member member) {
+		@Parameter(hidden = true) @MemberObject Member loginMember) {
 		RecipeCommentVO paramVO = RecipeCommentVO.of(recipeCommentRequest, recipeId,
-			member.getName());
-		return ApiResponse.onSuccess(recipeCommentService.saveRecipeComment(paramVO));
+			loginMember.getName());
+		return ApiResponse.onSuccess(recipeCommentService.saveRecipeComment(paramVO, loginMember));
 	}
 
 	@Operation(summary = "레시피북 댓글 수정", description = "레시피북 댓글을 수정합니다.")
 	@PatchMapping
 	public ApiResponse<RecipeCommentResponse> updateRecipeComment(
-		@RequestBody RecipeCommentRequest.Patch recipeCommentRequest) {
+		@RequestBody RecipeCommentRequest.Patch recipeCommentRequest,
+		@Parameter(hidden = true) @MemberObject Member loginMember) {
 		return ApiResponse.onSuccess(
-			recipeCommentService.updateRecipeComment(recipeCommentRequest));
+			recipeCommentService.updateRecipeComment(recipeCommentRequest, loginMember));
 	}
 
 	@Operation(summary = "레시피북 댓글 삭제", description = "레시피북 댓글을 삭제합니다.")
 	@Parameter(name = "recipeCommentId", description = "레시피북 댓글 Id, Query Param 입니다.", required = true, example = "1", in = ParameterIn.QUERY)
 	@DeleteMapping
 	public ApiResponse<RecipeCommentResponse> deleteRecipeComment(
-		@RequestParam Long recipeCommentId) {
-		return ApiResponse.onSuccess(recipeCommentService.deleteRecipeComment(recipeCommentId));
+		@RequestParam Long recipeCommentId,
+		@Parameter(hidden = true) @MemberObject Member loginMember) {
+		return ApiResponse.onSuccess(
+			recipeCommentService.deleteRecipeComment(recipeCommentId, loginMember));
 	}
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
@@ -6,21 +6,21 @@ import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentRequest;
 import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentResponse;
 import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentVO;
 
-import java.util.List;
-
 public interface RecipeCommentService {
 
-    RecipeCommentResponse.RecipeCommentResponseList getRecipeComment(Long recipeId, int page, Member loginMember);
+	RecipeCommentResponse.RecipeCommentResponseList getRecipeComment(Long recipeId, int page,
+		Member loginMember);
 
-    RecipeCommentResponse saveRecipeComment(RecipeCommentVO paramVO);
+	RecipeCommentResponse saveRecipeComment(RecipeCommentVO paramVO, Member loginMember);
 
-    RecipeComment getEntity(RecipeCommentVO paramVO);
+	RecipeComment getEntity(RecipeCommentVO paramVO, Member loginMember);
 
-    RecipeComment getParentEntityById(Long id);
+	RecipeComment getParentEntityById(Long id);
 
-    RecipeComment getEntityById(Long id);
+	RecipeComment getEntityById(Long id);
 
-    RecipeCommentResponse updateRecipeComment(RecipeCommentRequest.Patch requestDTO);
+	RecipeCommentResponse updateRecipeComment(RecipeCommentRequest.Patch requestDTO,
+		Member loginMember);
 
-    RecipeCommentResponse deleteRecipeComment(Long recipeCommentId);
+	RecipeCommentResponse deleteRecipeComment(Long recipeCommentId, Member loginMember);
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
@@ -1,8 +1,9 @@
 package com.example.dgbackend.domain.recipecomment.service;
 
+import static com.example.dgbackend.global.common.MemberValidator.isMatch;
+
 import com.example.dgbackend.domain.enums.State;
 import com.example.dgbackend.domain.member.Member;
-import com.example.dgbackend.domain.member.service.MemberService;
 import com.example.dgbackend.domain.recipe.Recipe;
 import com.example.dgbackend.domain.recipe.repository.RecipeRepository;
 import com.example.dgbackend.domain.recipecomment.RecipeComment;
@@ -13,97 +14,108 @@ import com.example.dgbackend.domain.recipecomment.repository.RecipeCommentReposi
 import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
 import com.example.dgbackend.global.exception.ApiException;
 import jakarta.transaction.Transactional;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 public class RecipeCommentServiceImpl implements RecipeCommentService {
 
-    private final RecipeCommentRepository recipeCommentRepository;
-    private final MemberService memberService;
-    private final RecipeRepository recipeRepository;
+	private final RecipeCommentRepository recipeCommentRepository;
+	private final RecipeRepository recipeRepository;
 
-    @Override
-    public RecipeCommentResponse.RecipeCommentResponseList getRecipeComment(Long recipeId, int page, Member loginMember) {
+	@Override
+	public RecipeCommentResponse.RecipeCommentResponseList getRecipeComment(Long recipeId, int page,
+		Member loginMember) {
 
-        Recipe recipe = recipeRepository.findById(recipeId).orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE));
+		Recipe recipe = recipeRepository.findById(recipeId)
+			.orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE));
 
-        Pageable pageable = Pageable.ofSize(10).withPage(page);
+		Pageable pageable = Pageable.ofSize(10).withPage(page);
 
-        Page<RecipeComment> recipeCommentPage = recipeCommentRepository.findByRecipeAndParentCommentIsNullAndStateIsTrueOrReported(recipe, pageable, loginMember.getId());
+		Page<RecipeComment> recipeCommentPage = recipeCommentRepository.findByRecipeAndParentCommentIsNullAndStateIsTrueOrReported(
+			recipe, pageable, loginMember.getId());
 
-        return RecipeCommentResponse.toResponseList(recipeCommentPage);
-    }
+		return RecipeCommentResponse.toResponseList(recipeCommentPage);
+	}
 
-    @Override
-    @Transactional
-    public RecipeCommentResponse saveRecipeComment(RecipeCommentVO paramVO) {
-        RecipeComment save = recipeCommentRepository.save(getEntity(paramVO));
+	@Override
+	@Transactional
+	public RecipeCommentResponse saveRecipeComment(RecipeCommentVO paramVO, Member loginMember) {
+		RecipeComment save = recipeCommentRepository.save(getEntity(paramVO, loginMember));
 
-        //댓글 수 증가
-        save.getRecipe().changeCommentCount(true);
-        return RecipeCommentResponse.toResponse(save);
-    }
+		//댓글 수 증가
+		save.getRecipe().changeCommentCount(true);
+		return RecipeCommentResponse.toResponse(save);
+	}
 
-    @Override
-    public RecipeComment getEntity(RecipeCommentVO paramVO) {
-        Member member = memberService.findMemberByName(paramVO.getMemberName());
-        Recipe recipe = recipeRepository.findById(paramVO.getRecipeId()).orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE));
-        String content = paramVO.getContent();
+	@Override
+	public RecipeComment getEntity(RecipeCommentVO paramVO, Member loginMember) {
+		Recipe recipe = recipeRepository.findById(paramVO.getRecipeId())
+			.orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE));
+		String content = paramVO.getContent();
 
-        return Optional.ofNullable(paramVO.getParentId())
+		return Optional.ofNullable(paramVO.getParentId())
 
-                //대댓글 일 때
-                .filter(parentId -> parentId != 0)
-                .map(parentId -> RecipeCommentRequest.toEntity(member, recipe, content, getParentEntityById(parentId)))
+			//대댓글 일 때
+			.filter(parentId -> parentId != 0)
+			.map(parentId -> RecipeCommentRequest.toEntity(loginMember, recipe, content,
+				getParentEntityById(parentId)))
 
-                //댓글 일 때
-                .orElse(RecipeCommentRequest.toEntity(member, recipe, content, null));
-    }
+			//댓글 일 때
+			.orElse(RecipeCommentRequest.toEntity(loginMember, recipe, content, null));
+	}
 
-    @Override
-    public RecipeComment getParentEntityById(Long parentId) {
-        RecipeComment ParentRecipeComment = getEntityById(parentId);
+	@Override
+	public RecipeComment getParentEntityById(Long parentId) {
+		RecipeComment ParentRecipeComment = getEntityById(parentId);
 
-        //부모의 부모 댓글이 존재할 경우
-        if (ParentRecipeComment.getParentComment() != null) {
-            throw new ApiException(ErrorStatus._OVER_DEPTH_RECIPE_COMMENT);
-        }
+		//부모의 부모 댓글이 존재할 경우
+		if (ParentRecipeComment.getParentComment() != null) {
+			throw new ApiException(ErrorStatus._OVER_DEPTH_RECIPE_COMMENT);
+		}
 
-        return ParentRecipeComment;
-    }
+		return ParentRecipeComment;
+	}
 
-    @Override
-    public RecipeComment getEntityById(Long id) {
-        return recipeCommentRepository.findById(id)
-                .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE_COMMENT));
-    }
+	@Override
+	public RecipeComment getEntityById(Long id) {
+		return recipeCommentRepository.findById(id)
+			.orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE_COMMENT));
+	}
 
-    @Override
-    @Transactional
-    public RecipeCommentResponse updateRecipeComment(RecipeCommentRequest.Patch requestDTO) {
-        RecipeComment recipeComment = getEntityById(requestDTO.getRecipeCommentId()).update(requestDTO.getContent());
-        return RecipeCommentResponse.toResponse(recipeComment);
-    }
+	@Override
+	@Transactional
+	public RecipeCommentResponse updateRecipeComment(RecipeCommentRequest.Patch requestDTO,
+		Member loginMember) {
 
-    @Override
-    @Transactional
-    public RecipeCommentResponse deleteRecipeComment(Long recipeCommentId) {
-        RecipeComment entityById = getEntityById(recipeCommentId);
+		RecipeComment recipeComment = getEntityById(requestDTO.getRecipeCommentId());
+		if (isMatch(loginMember, recipeComment.getMember())) {
+			return RecipeCommentResponse.toResponse(recipeComment.update(requestDTO.getContent()));
+		} else {
+			throw new ApiException(ErrorStatus._INVALID_MEMBER);
+		}
+	}
 
-        if (entityById.getState().equals(State.FALSE)) {
-            throw new ApiException(ErrorStatus._Already_DELETE_RECIPE_COMMENT);
-        }
+	@Override
+	@Transactional
+	public RecipeCommentResponse deleteRecipeComment(Long recipeCommentId, Member loginMember) {
+		RecipeComment recipeComment = getEntityById(recipeCommentId);
 
-        RecipeComment recipeComment = entityById.delete();
+		if (recipeComment.getState().equals(State.FALSE)) {
+			throw new ApiException(ErrorStatus._Already_DELETE_RECIPE_COMMENT);
+		}
 
-        //대댓글도 삭제
-        recipeComment.getChildCommentList().forEach(RecipeComment::delete);
-        return RecipeCommentResponse.toResponse(recipeComment);
-    }
+		if (isMatch(loginMember, recipeComment.getMember())) {
+			//대댓글도 삭제 -> 대댓글 구현시 수정
+			//recipeComment.getChildCommentList().forEach(RecipeComment::delete);
+			return RecipeCommentResponse.toResponse(recipeComment.delete());
+		} else {
+			throw new ApiException(ErrorStatus._INVALID_MEMBER);
+		}
+
+	}
 }

--- a/src/main/java/com/example/dgbackend/global/common/MemberValidator.java
+++ b/src/main/java/com/example/dgbackend/global/common/MemberValidator.java
@@ -1,0 +1,20 @@
+package com.example.dgbackend.global.common;
+
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
+import com.example.dgbackend.global.exception.ApiException;
+
+public class MemberValidator {
+
+	//현재 viewer와 작성자가 같지 않으면 예외 처리
+	public static void match(Member viewer, Member writer) {
+		if ((viewer == null) || !(viewer.getId().equals(writer.getId()))) {
+			throw new ApiException(ErrorStatus._INVALID_MEMBER);
+		}
+	}
+
+	//현재 viewer와 작성자가 같으면 수정/삭제 권한 부여(true 리턴)
+	public static boolean isMatch(Member viewer, Member writer) {
+		return (viewer != null) && (viewer.getId().equals(writer.getId()));
+	}
+}

--- a/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
@@ -21,7 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _PERMANENTLY_REPORTED_MEMBER(HttpStatus.FORBIDDEN, "MEMBER_003", "해당 사용자는 영구 정지되었습니다."),
     _TEMPORARILY_REPORTED_MEMBER(HttpStatus.FORBIDDEN, "MEMBER_004", "해당 사용자는 일시 정지되었습니다."),
     _DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "MEMBER_005", "해당 닉네임은 중복된 닉네임입니다."),
-    _INVALID_MEMBER(HttpStatus.BAD_REQUEST, "MEMBER_006", "유효하지 않은 사용자Feat: Add _INVALID_MEMBE입니다."),
+    _INVALID_MEMBER(HttpStatus.BAD_REQUEST, "MEMBER_006", "유효하지 않은 사용자입니다."),
 
     //오늘의 조합 관련
     _COMBINATION_NOT_FOUND(HttpStatus.NOT_FOUND, "COMBINATION_001", "존재하지 않는 오늘의 조합입니다."),

--- a/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/dgbackend/global/common/response/code/status/ErrorStatus.java
@@ -21,6 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _PERMANENTLY_REPORTED_MEMBER(HttpStatus.FORBIDDEN, "MEMBER_003", "해당 사용자는 영구 정지되었습니다."),
     _TEMPORARILY_REPORTED_MEMBER(HttpStatus.FORBIDDEN, "MEMBER_004", "해당 사용자는 일시 정지되었습니다."),
     _DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "MEMBER_005", "해당 닉네임은 중복된 닉네임입니다."),
+    _INVALID_MEMBER(HttpStatus.BAD_REQUEST, "MEMBER_006", "유효하지 않은 사용자Feat: Add _INVALID_MEMBE입니다."),
 
     //오늘의 조합 관련
     _COMBINATION_NOT_FOUND(HttpStatus.NOT_FOUND, "COMBINATION_001", "존재하지 않는 오늘의 조합입니다."),


### PR DESCRIPTION
## 요약

- 레시피 도메인 리팩토링과 오류를 해결하고, 멤버 검증 기능을 구현하였습니다.

## 상세 내용

- 제가 작업한 파일들에 대해서 코딩 컨벤션을 적용하였습니다. 코딩 컨벤션은 다른 이슈를 통해 모든 파일에 적용할 예정입니다!
- 간단히 요약하면, 레시피 도메인 오류 해결 및 멤버 어노테이션 적용을 위해 코드를 수정하였습니다.
- 해당 부분을 진행하면서, 멤버 검증 클래스를 추가하였습니다. (MemberValidator) 위치: global - common - MemberValidator 클래스
   - 해당 클래스는 여러분들도 사용하면 좋을 것 같습니다!
   - viewer와 writer가 동일한지 검증하는 로직입니다. Combination 도메인 API에도 적용하도록 하겠습니다.
   - `isMatch` 또는 `match`함수를 를 본인 기능에 맞게 사용하시면 됩니다.
- 따라서 레시피 댓글 작성 시 현재 로그인한 멤버에 맞게 Entity 저장하도록 수정하여 에러를 해결하였습니다!
- `ErrorStatus` 에 `_INVALID_MEMBER`를 추가하였으니, 사용하시면 됩니다.

## 질문 및 이외 사항

- 오래걸려서 죄송합니다 ㅠㅠ 앞으로 빠르게 작업하도록 하겠습니다!

## 이슈 번호

- close #169 