### PR TITLE
Feat: 새 유저/기존 유저 구분 API

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/example/dgbackend/domain/member/dto/MemberRequest.java
@@ -40,7 +40,7 @@ public class MemberRequest {
         private Gender gender;
     }
 
-    public static Member toEntity(AuthRequest authRequest) {
+    public static Member toEntity(AuthRequest.AuthDTO authRequest) {
         return Member.builder()
             .name(authRequest.getName())
             .nickName(authRequest.getNickName())

--- a/src/main/java/com/example/dgbackend/global/jwt/controller/JwtController.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/controller/JwtController.java
@@ -33,27 +33,37 @@ public class JwtController {
         return authService.reIssueAccessToken(request);
     }
 
+    @Operation(summary = "카카오 소셜 로그인")
     @PostMapping("/kakao")
-    public ApiResponse<AuthResponse> kakaoLoign(@RequestBody AuthRequest authRequest,
+    public ApiResponse<AuthResponse.AuthResult> kakaoLoign(@RequestBody AuthRequest.AuthDTO authRequest,
         HttpServletResponse response) throws IOException {
         return ApiResponse.onSuccess(authService.loginOrJoin(response, authRequest));
     }
 
+    @Operation(summary = "애플 소셜 로그인")
     @PostMapping("/apple")
-    public ApiResponse<AuthResponse> appleLoign(@RequestBody AuthRequest authRequest,
+    public ApiResponse<AuthResponse.AuthResult> appleLoign(@RequestBody AuthRequest.AuthDTO authRequest,
         HttpServletResponse response) throws IOException {
         return ApiResponse.onSuccess(authService.loginOrJoin(response, authRequest));
     }
 
+    @Operation(summary = "네이버 소셜 로그인")
     @PostMapping("/naver")
-    public ApiResponse<AuthResponse> naverLoign(@RequestBody AuthRequest authRequest,
+    public ApiResponse<AuthResponse.AuthResult> naverLoign(@RequestBody AuthRequest.AuthDTO authRequest,
         HttpServletResponse response) throws IOException {
         return ApiResponse.onSuccess(authService.loginOrJoin(response, authRequest));
     }
 
+    @Operation(summary = "로그아웃")
     @PatchMapping("/logout")
     public ApiResponse<String> logout(HttpServletResponse response,
                                                 HttpServletRequest request) throws IOException {
         return ApiResponse.onSuccess(authService.logout(request, response));
+    }
+
+    @Operation(summary = "새 유저/기존 유저 구분")
+    @PostMapping("/user-division")
+    public ApiResponse<AuthResponse.IsSignedUpResult> userDivision(@RequestBody AuthRequest.SignedUpDTO authRequest) throws IOException {
+        return ApiResponse.onSuccess(authService.isSignedUp(authRequest));
     }
 }

--- a/src/main/java/com/example/dgbackend/global/jwt/dto/AuthRequest.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/dto/AuthRequest.java
@@ -1,19 +1,33 @@
 package com.example.dgbackend.global.jwt.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Schema(name = "사용자 정보")
-@Getter
 public class AuthRequest {
 
-    private String name;
-    private String profileImage;
-    private String email;
-    private String nickName;
-    private String birthDate;
-    private String phoneNumber;
-    private String gender;
-    private String provider;
-    private String providerId;
+    @Schema(name = "사용자 정보")
+    @Getter
+    public static class AuthDTO {
+        private String name;
+        private String profileImage;
+        private String email;
+        private String nickName;
+        private String birthDate;
+        private String phoneNumber;
+        private String gender;
+        private String provider;
+        private String providerId;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class SignedUpDTO {
+        private String provider;
+        private String providerId;
+    }
 }

--- a/src/main/java/com/example/dgbackend/global/jwt/dto/AuthResponse.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/dto/AuthResponse.java
@@ -6,26 +6,43 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Builder
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
 public class AuthResponse {
 
-    private String provider;
-    private String nickName;
-    private Long memberId;
-    private boolean newMember;
-    private LocalDateTime createdAt;
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class AuthResult {
+        private String provider;
+        private String nickName;
+        private Long memberId;
+        private boolean newMember;
+        private LocalDateTime createdAt;
+    }
 
-    public static AuthResponse toAuthResponse(String provider, String nickName, boolean newMember, Long memberId) {
+    public static AuthResult toAuthResult(String provider, String nickName, boolean newMember, Long memberId) {
 
-        return AuthResponse.builder()
+        return AuthResult.builder()
             .provider(provider)
             .nickName(nickName)
             .memberId(memberId)
             .newMember(newMember)
             .createdAt(LocalDateTime.now())
             .build();
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class IsSignedUpResult {
+        private Boolean isSignedUp;
+    }
+
+    public static IsSignedUpResult toIsSignedUpResult(Boolean isSignedUp) {
+
+        return IsSignedUpResult.builder()
+                .isSignedUp(isSignedUp)
+                .build();
     }
 }

--- a/src/main/java/com/example/dgbackend/global/jwt/service/AuthService.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/service/AuthService.java
@@ -37,7 +37,7 @@ public class AuthService {
     /**
      * 회원가입 및 로그인 진행
      */
-    public AuthResponse loginOrJoin(HttpServletResponse response, AuthRequest authRequest)
+    public AuthResponse.AuthResult loginOrJoin(HttpServletResponse response, AuthRequest.AuthDTO authRequest)
         throws IOException {
 
         String id = authRequest.getProvider() + "_" + authRequest.getProviderId();
@@ -75,7 +75,7 @@ public class AuthService {
         registerHeaderToken(response, id, "Authorization");
         registerHeaderToken(response, id, "RefreshToken");
 
-        return AuthResponse.toAuthResponse(authRequest.getProvider(), authRequest.getNickName(),isNewMember,
+        return AuthResponse.toAuthResult(authRequest.getProvider(), authRequest.getNickName(),isNewMember,
             memberId);
 
     }
@@ -165,5 +165,17 @@ public class AuthService {
             "============================================= Access Token 재발급 : " + newAcessToken);
 
         return ResponseEntity.ok().headers(httpHeaders).build();
+    }
+
+    /**
+     * 새 유저/기존 유저 구분
+     */
+    public AuthResponse.IsSignedUpResult isSignedUp(AuthRequest.SignedUpDTO authRequest) {
+        Boolean isSigned = false;
+
+        //Member Repository에서 있는지 검사
+        isSigned = memberQueryService.existsByProviderAndProviderId(authRequest.getProvider(), authRequest.getProviderId());
+
+        return AuthResponse.toIsSignedUpResult(isSigned);
     }
 }


### PR DESCRIPTION
## 요약

- Provider와 ProviderId만 보내었을 때 가입된 유저인지 새로 가입한 유저인지 반환하는 API

## 상세 내용

- API 내용
<img width="955" alt="스크린샷 2024-07-24 오후 5 42 22" src="https://github.com/user-attachments/assets/34a09e40-f315-4208-9cb1-7fe3813e771a">

- 가입되지 않은 유저일 때
<img width="1422" alt="스크린샷 2024-07-24 오후 5 38 49" src="https://github.com/user-attachments/assets/16e4f40f-119d-4b13-a043-9ca7a8f4c034">

- 가입한 유저일 때
<img width="1222" alt="스크린샷 2024-07-24 오후 5 39 12" src="https://github.com/user-attachments/assets/2668ba50-8ef2-43ba-829c-739b8a2f2c9a">

## 질문 및 이외 사항

-

## 이슈 번호

- #218 