### PR TITLE
220 [FEAT] 약관 기능 구현

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/term/Term.java
+++ b/src/main/java/com/example/dgbackend/domain/term/Term.java
@@ -3,6 +3,8 @@ package com.example.dgbackend.domain.term;
 import com.example.dgbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,10 +22,11 @@ public class Term extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Term id;
+    private Long id;
 
     @NotNull
-    private String title;
+    @Enumerated(EnumType.STRING)
+    private TermType termType;
 
     @NotNull
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/com/example/dgbackend/domain/term/Term.java
+++ b/src/main/java/com/example/dgbackend/domain/term/Term.java
@@ -1,6 +1,7 @@
 package com.example.dgbackend.domain.term;
 
 import com.example.dgbackend.global.common.BaseTimeEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -19,12 +20,13 @@ public class Term extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Term id;
 
     @NotNull
     private String title;
 
     @NotNull
+    @Column(columnDefinition = "TEXT")
     private String content;
 
     private boolean optional = true; // true: 필수, false: 선택

--- a/src/main/java/com/example/dgbackend/domain/term/TermType.java
+++ b/src/main/java/com/example/dgbackend/domain/term/TermType.java
@@ -1,16 +1,16 @@
 package com.example.dgbackend.domain.term;
 
 /*
-    * 이용약관 종류
-    * [필수 약관]
-    * PRIVACY: 사용자 데이터 및 개인정보 보호 정책
-    * CONTENT: 사용자 콘텐츠 정책
-    * AGE: 연령 제한 정책
-    * COPYRIGHT: 저작권 및 상표 정책
-    * SERVICE_CHANGE: 서비스 변경 및 중단 정책
-    *
-    * [선택 약관]
-    * MARKETING: 마케팅 동의 정책
+ * 이용약관 종류
+ * [필수 약관]
+ * PRIVACY: 사용자 데이터 및 개인정보 보호 정책
+ * CONTENT: 사용자 콘텐츠 정책
+ * AGE: 연령 제한 정책
+ * COPYRIGHT: 저작권 및 상표 정책
+ * SERVICE_CHANGE: 서비스 변경 및 중단 정책
+ *
+ * [선택 약관]
+ * MARKETING: 마케팅 동의 정책
  */
 public enum TermType {
     PRIVACY, CONTENT, AGE, COPYRIGHT, SERVICE_CHANGE, MARKETING

--- a/src/main/java/com/example/dgbackend/domain/term/TermType.java
+++ b/src/main/java/com/example/dgbackend/domain/term/TermType.java
@@ -1,0 +1,17 @@
+package com.example.dgbackend.domain.term;
+
+/*
+    * 이용약관 종류
+    * [필수 약관]
+    * PRIVACY: 사용자 데이터 및 개인정보 보호 정책
+    * CONTENT: 사용자 콘텐츠 정책
+    * AGE: 연령 제한 정책
+    * COPYRIGHT: 저작권 및 상표 정책
+    * SERVICE_CHANGE: 서비스 변경 및 중단 정책
+    *
+    * [선택 약관]
+    * MARKETING: 마케팅 동의 정책
+ */
+public enum TermType {
+    PRIVACY, CONTENT, AGE, COPYRIGHT, SERVICE_CHANGE, MARKETING
+}

--- a/src/main/java/com/example/dgbackend/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/term/repository/TermRepository.java
@@ -2,7 +2,6 @@ package com.example.dgbackend.domain.term.repository;
 
 import com.example.dgbackend.domain.term.Term;
 import com.example.dgbackend.domain.term.TermType;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/example/dgbackend/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/term/repository/TermRepository.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TermRepository extends JpaRepository<Term, Long> {
+
     Term findByTermType(TermType termType);
 
 }

--- a/src/main/java/com/example/dgbackend/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/term/repository/TermRepository.java
@@ -1,0 +1,13 @@
+package com.example.dgbackend.domain.term.repository;
+
+import com.example.dgbackend.domain.term.Term;
+import com.example.dgbackend.domain.term.TermType;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TermRepository extends JpaRepository<Term, Long> {
+    Term findByTermType(TermType termType);
+
+}

--- a/src/main/java/com/example/dgbackend/domain/termagree/TermAgree.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/TermAgree.java
@@ -12,10 +12,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity

--- a/src/main/java/com/example/dgbackend/domain/termagree/TermAgree.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/TermAgree.java
@@ -25,8 +25,6 @@ public class TermAgree extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private boolean approve = true; //true: 동의, false: 비동의
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/com/example/dgbackend/domain/termagree/controller/TermAgreeController.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/controller/TermAgreeController.java
@@ -1,0 +1,43 @@
+package com.example.dgbackend.domain.termagree.controller;
+
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.termagree.dto.TermRequestDTO.TermAgreeRequestDTO;
+import com.example.dgbackend.domain.termagree.dto.TermRequestDTO.TermDisagreeRequestDTO;
+import com.example.dgbackend.domain.termagree.dto.TermResponseDTO.MemberTermAgreeResponseDTO;
+import com.example.dgbackend.domain.termagree.dto.TermResponseDTO.TermAgreeResponseDTO;
+import com.example.dgbackend.domain.termagree.dto.TermResponseDTO.TermDisagreeResponseDTO;
+import com.example.dgbackend.domain.termagree.service.TermAgreeCommandService;
+import com.example.dgbackend.domain.termagree.service.TermAgreeQueryService;
+import com.example.dgbackend.global.common.response.ApiResponse;
+import com.example.dgbackend.global.jwt.annotation.MemberObject;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/term-agree")
+public class TermAgreeController {
+
+    private final TermAgreeCommandService termAgreeCommandService;
+    private final TermAgreeQueryService termAgreeQueryService;
+
+    @PostMapping("/agree")
+    public ApiResponse<TermAgreeResponseDTO> termAgree(@MemberObject Member member, @RequestBody TermAgreeRequestDTO termAgreeRequestDTO){
+        return ApiResponse.onSuccess(termAgreeCommandService.termAgree(member, termAgreeRequestDTO));
+    }
+
+    @PostMapping("/disagree")
+    public ApiResponse<TermDisagreeResponseDTO> termDisagree(@MemberObject Member member, @RequestBody TermDisagreeRequestDTO termDisagreeRequestDTO){
+        return ApiResponse.onSuccess(termAgreeCommandService.termDisagree(member, termDisagreeRequestDTO));
+    }
+
+    @GetMapping("/list")
+    public ApiResponse<MemberTermAgreeResponseDTO> getMemberTermAgreeList(@MemberObject Member member){
+        return ApiResponse.onSuccess(termAgreeQueryService.getMemberTermAgree(member));
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/domain/termagree/controller/TermAgreeController.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/controller/TermAgreeController.java
@@ -26,17 +26,22 @@ public class TermAgreeController {
     private final TermAgreeQueryService termAgreeQueryService;
 
     @PostMapping("/agree")
-    public ApiResponse<TermAgreeResponseDTO> termAgree(@MemberObject Member member, @RequestBody TermAgreeRequestDTO termAgreeRequestDTO){
-        return ApiResponse.onSuccess(termAgreeCommandService.termAgree(member, termAgreeRequestDTO));
+    public ApiResponse<TermAgreeResponseDTO> termAgree(@MemberObject Member member,
+        @RequestBody TermAgreeRequestDTO termAgreeRequestDTO) {
+        return ApiResponse.onSuccess(
+            termAgreeCommandService.termAgree(member, termAgreeRequestDTO));
     }
 
     @PostMapping("/disagree")
-    public ApiResponse<TermDisagreeResponseDTO> termDisagree(@MemberObject Member member, @RequestBody TermDisagreeRequestDTO termDisagreeRequestDTO){
-        return ApiResponse.onSuccess(termAgreeCommandService.termDisagree(member, termDisagreeRequestDTO));
+    public ApiResponse<TermDisagreeResponseDTO> termDisagree(@MemberObject Member member,
+        @RequestBody TermDisagreeRequestDTO termDisagreeRequestDTO) {
+        return ApiResponse.onSuccess(
+            termAgreeCommandService.termDisagree(member, termDisagreeRequestDTO));
     }
 
     @GetMapping("/list")
-    public ApiResponse<MemberTermAgreeResponseDTO> getMemberTermAgreeList(@MemberObject Member member){
+    public ApiResponse<MemberTermAgreeResponseDTO> getMemberTermAgreeList(
+        @MemberObject Member member) {
         return ApiResponse.onSuccess(termAgreeQueryService.getMemberTermAgree(member));
     }
 

--- a/src/main/java/com/example/dgbackend/domain/termagree/dto/TermRequestDTO.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/dto/TermRequestDTO.java
@@ -1,0 +1,29 @@
+package com.example.dgbackend.domain.termagree.dto;
+
+import com.example.dgbackend.domain.term.TermType;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+public class TermRequestDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TermAgreeRequestDTO {
+        private List<TermType> termList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TermDisagreeRequestDTO {
+        private List<TermType> termList;
+    }
+
+}

--- a/src/main/java/com/example/dgbackend/domain/termagree/dto/TermRequestDTO.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/dto/TermRequestDTO.java
@@ -14,6 +14,7 @@ public class TermRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class TermAgreeRequestDTO {
+
         private List<TermType> termList;
     }
 
@@ -22,6 +23,7 @@ public class TermRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class TermDisagreeRequestDTO {
+
         private List<TermType> termList;
     }
 

--- a/src/main/java/com/example/dgbackend/domain/termagree/dto/TermRequestDTO.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/dto/TermRequestDTO.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 public class TermRequestDTO {
 

--- a/src/main/java/com/example/dgbackend/domain/termagree/dto/TermResponseDTO.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/dto/TermResponseDTO.java
@@ -1,0 +1,38 @@
+package com.example.dgbackend.domain.termagree.dto;
+
+import com.example.dgbackend.domain.term.TermType;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+public class TermResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TermAgreeResponseDTO {
+        private Long memberID;
+        private List<TermType> termList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TermDisagreeResponseDTO {
+        private Long memberID;
+        private List<TermType> termList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberTermAgreeResponseDTO {
+        private Long memberID;
+        private List<TermType> termList;
+    }
+}

--- a/src/main/java/com/example/dgbackend/domain/termagree/dto/TermResponseDTO.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/dto/TermResponseDTO.java
@@ -9,11 +9,13 @@ import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 public class TermResponseDTO {
+
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class TermAgreeResponseDTO {
+
         private Long memberID;
         private List<TermType> termList;
     }
@@ -23,6 +25,7 @@ public class TermResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class TermDisagreeResponseDTO {
+
         private Long memberID;
         private List<TermType> termList;
     }
@@ -32,6 +35,7 @@ public class TermResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MemberTermAgreeResponseDTO {
+
         private Long memberID;
         private List<TermType> termList;
     }

--- a/src/main/java/com/example/dgbackend/domain/termagree/repository/TermAgreeRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/repository/TermAgreeRepository.java
@@ -1,7 +1,5 @@
 package com.example.dgbackend.domain.termagree.repository;
 
-import com.example.dgbackend.domain.member.Member;
-import com.example.dgbackend.domain.term.Term;
 import com.example.dgbackend.domain.termagree.TermAgree;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/example/dgbackend/domain/termagree/repository/TermAgreeRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/repository/TermAgreeRepository.java
@@ -1,0 +1,13 @@
+package com.example.dgbackend.domain.termagree.repository;
+
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.term.Term;
+import com.example.dgbackend.domain.termagree.TermAgree;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TermAgreeRepository extends JpaRepository<TermAgree, Long> {
+    List<TermAgree> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/example/dgbackend/domain/termagree/repository/TermAgreeRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/repository/TermAgreeRepository.java
@@ -7,5 +7,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TermAgreeRepository extends JpaRepository<TermAgree, Long> {
+
     List<TermAgree> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/example/dgbackend/domain/termagree/service/TermAgreeCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/service/TermAgreeCommandService.java
@@ -7,6 +7,9 @@ import com.example.dgbackend.domain.termagree.dto.TermResponseDTO.TermAgreeRespo
 import com.example.dgbackend.domain.termagree.dto.TermResponseDTO.TermDisagreeResponseDTO;
 
 public interface TermAgreeCommandService {
+
     TermAgreeResponseDTO termAgree(Member member, TermAgreeRequestDTO termAgreeRequestDTO);
-    TermDisagreeResponseDTO termDisagree(Member member, TermDisagreeRequestDTO termDisagreeRequestDTO);
+
+    TermDisagreeResponseDTO termDisagree(Member member,
+        TermDisagreeRequestDTO termDisagreeRequestDTO);
 }

--- a/src/main/java/com/example/dgbackend/domain/termagree/service/TermAgreeCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/service/TermAgreeCommandService.java
@@ -1,0 +1,12 @@
+package com.example.dgbackend.domain.termagree.service;
+
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.termagree.dto.TermRequestDTO.TermAgreeRequestDTO;
+import com.example.dgbackend.domain.termagree.dto.TermRequestDTO.TermDisagreeRequestDTO;
+import com.example.dgbackend.domain.termagree.dto.TermResponseDTO.TermAgreeResponseDTO;
+import com.example.dgbackend.domain.termagree.dto.TermResponseDTO.TermDisagreeResponseDTO;
+
+public interface TermAgreeCommandService {
+    TermAgreeResponseDTO termAgree(Member member, TermAgreeRequestDTO termAgreeRequestDTO);
+    TermDisagreeResponseDTO termDisagree(Member member, TermDisagreeRequestDTO termDisagreeRequestDTO);
+}

--- a/src/main/java/com/example/dgbackend/domain/termagree/service/TermAgreeCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/service/TermAgreeCommandServiceImpl.java
@@ -1,0 +1,82 @@
+package com.example.dgbackend.domain.termagree.service;
+
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.term.Term;
+import com.example.dgbackend.domain.term.TermType;
+import com.example.dgbackend.domain.term.repository.TermRepository;
+import com.example.dgbackend.domain.termagree.TermAgree;
+import com.example.dgbackend.domain.termagree.dto.TermRequestDTO.TermAgreeRequestDTO;
+import com.example.dgbackend.domain.termagree.dto.TermRequestDTO.TermDisagreeRequestDTO;
+import com.example.dgbackend.domain.termagree.dto.TermResponseDTO.TermAgreeResponseDTO;
+import com.example.dgbackend.domain.termagree.dto.TermResponseDTO.TermDisagreeResponseDTO;
+import com.example.dgbackend.domain.termagree.repository.TermAgreeRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TermAgreeCommandServiceImpl implements TermAgreeCommandService {
+    private final TermAgreeRepository termAgreeRepository;
+    private final TermRepository termRepository;
+
+    @Override
+    public TermAgreeResponseDTO termAgree(Member member, TermAgreeRequestDTO termAgreeRequestDTO) {
+        List<Term> termList = termAgreeRequestDTO.getTermList().stream().map(termRepository::findByTermType).toList();
+
+        List<Term> alreadyAgreedTermList = new ArrayList<>();
+        List<TermAgree> memberTermAgreeList = termAgreeRepository.findAllByMemberId(member.getId());
+        if (memberTermAgreeList != null) {
+            alreadyAgreedTermList = memberTermAgreeList.stream().map(TermAgree::getTerm).toList();
+        }
+
+        List<TermType> savedList = new ArrayList<>();
+        for (Term term : termList) {
+            if(alreadyAgreedTermList.contains(term))
+                continue;
+
+            savedList.add(term.getTermType());
+            termAgreeRepository.save(termAgreeRepository.save(
+                TermAgree.builder()
+                    .term(term)
+                    .member(member)
+                    .build()));
+        }
+
+        return TermAgreeResponseDTO.builder()
+            .memberID(member.getId())
+            .termList(savedList)
+            .build();
+    }
+
+    @Override
+    public TermDisagreeResponseDTO termDisagree(Member member,
+        TermDisagreeRequestDTO termDisagreeRequestDTO) {
+        List<Term> deleteList = termDisagreeRequestDTO.getTermList().stream().map(termRepository::findByTermType).toList();
+
+        List<TermAgree> alreadyAgreedTermList = termAgreeRepository.findAllByMemberId(member.getId());
+        if (alreadyAgreedTermList == null) {
+            return TermDisagreeResponseDTO.builder()
+                .memberID(member.getId())
+                .termList(new ArrayList<>())
+                .build();
+        }
+
+        List<TermType> savedList = new ArrayList<>();
+        for (TermAgree termAgree : alreadyAgreedTermList){
+            if(!deleteList.contains(termAgree.getTerm()))
+                continue;
+
+            savedList.add(termAgree.getTerm().getTermType());
+            termAgreeRepository.delete(termAgree);
+        }
+
+        return TermDisagreeResponseDTO.builder()
+            .memberID(member.getId())
+            .termList(savedList)
+            .build();
+    }
+}

--- a/src/main/java/com/example/dgbackend/domain/termagree/service/TermAgreeCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/service/TermAgreeCommandServiceImpl.java
@@ -20,12 +20,14 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Slf4j
 public class TermAgreeCommandServiceImpl implements TermAgreeCommandService {
+
     private final TermAgreeRepository termAgreeRepository;
     private final TermRepository termRepository;
 
     @Override
     public TermAgreeResponseDTO termAgree(Member member, TermAgreeRequestDTO termAgreeRequestDTO) {
-        List<Term> termList = termAgreeRequestDTO.getTermList().stream().map(termRepository::findByTermType).toList();
+        List<Term> termList = termAgreeRequestDTO.getTermList().stream()
+            .map(termRepository::findByTermType).toList();
 
         List<Term> alreadyAgreedTermList = new ArrayList<>();
         List<TermAgree> memberTermAgreeList = termAgreeRepository.findAllByMemberId(member.getId());
@@ -35,8 +37,9 @@ public class TermAgreeCommandServiceImpl implements TermAgreeCommandService {
 
         List<TermType> savedList = new ArrayList<>();
         for (Term term : termList) {
-            if(alreadyAgreedTermList.contains(term))
+            if (alreadyAgreedTermList.contains(term)) {
                 continue;
+            }
 
             savedList.add(term.getTermType());
             termAgreeRepository.save(termAgreeRepository.save(
@@ -55,9 +58,11 @@ public class TermAgreeCommandServiceImpl implements TermAgreeCommandService {
     @Override
     public TermDisagreeResponseDTO termDisagree(Member member,
         TermDisagreeRequestDTO termDisagreeRequestDTO) {
-        List<Term> deleteList = termDisagreeRequestDTO.getTermList().stream().map(termRepository::findByTermType).toList();
+        List<Term> deleteList = termDisagreeRequestDTO.getTermList().stream()
+            .map(termRepository::findByTermType).toList();
 
-        List<TermAgree> alreadyAgreedTermList = termAgreeRepository.findAllByMemberId(member.getId());
+        List<TermAgree> alreadyAgreedTermList = termAgreeRepository.findAllByMemberId(
+            member.getId());
         if (alreadyAgreedTermList == null) {
             return TermDisagreeResponseDTO.builder()
                 .memberID(member.getId())
@@ -66,9 +71,10 @@ public class TermAgreeCommandServiceImpl implements TermAgreeCommandService {
         }
 
         List<TermType> savedList = new ArrayList<>();
-        for (TermAgree termAgree : alreadyAgreedTermList){
-            if(!deleteList.contains(termAgree.getTerm()))
+        for (TermAgree termAgree : alreadyAgreedTermList) {
+            if (!deleteList.contains(termAgree.getTerm())) {
                 continue;
+            }
 
             savedList.add(termAgree.getTerm().getTermType());
             termAgreeRepository.delete(termAgree);

--- a/src/main/java/com/example/dgbackend/domain/termagree/service/TermAgreeQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/service/TermAgreeQueryService.java
@@ -1,0 +1,9 @@
+package com.example.dgbackend.domain.termagree.service;
+
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.termagree.dto.TermResponseDTO.MemberTermAgreeResponseDTO;
+
+public interface TermAgreeQueryService {
+    MemberTermAgreeResponseDTO getMemberTermAgree(Member member);
+
+}

--- a/src/main/java/com/example/dgbackend/domain/termagree/service/TermAgreeQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/service/TermAgreeQueryService.java
@@ -4,6 +4,7 @@ import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.termagree.dto.TermResponseDTO.MemberTermAgreeResponseDTO;
 
 public interface TermAgreeQueryService {
+
     MemberTermAgreeResponseDTO getMemberTermAgree(Member member);
 
 }

--- a/src/main/java/com/example/dgbackend/domain/termagree/service/TermAgreeQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/service/TermAgreeQueryServiceImpl.java
@@ -1,0 +1,28 @@
+package com.example.dgbackend.domain.termagree.service;
+
+import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.term.Term;
+import com.example.dgbackend.domain.termagree.TermAgree;
+import com.example.dgbackend.domain.termagree.dto.TermResponseDTO.MemberTermAgreeResponseDTO;
+import com.example.dgbackend.domain.termagree.repository.TermAgreeRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TermAgreeQueryServiceImpl implements TermAgreeQueryService{
+    private final TermAgreeRepository termAgreeRepository;
+
+    @Override
+    public MemberTermAgreeResponseDTO getMemberTermAgree(Member member) {
+        List<TermAgree> termAgreeList = termAgreeRepository.findAllByMemberId(member.getId());
+
+        return MemberTermAgreeResponseDTO.builder()
+            .memberID(member.getId())
+            .termList(termAgreeList.stream().map(TermAgree::getTerm).map(Term::getTermType).toList())
+            .build();
+    }
+}

--- a/src/main/java/com/example/dgbackend/domain/termagree/service/TermAgreeQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/termagree/service/TermAgreeQueryServiceImpl.java
@@ -13,7 +13,8 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class TermAgreeQueryServiceImpl implements TermAgreeQueryService{
+public class TermAgreeQueryServiceImpl implements TermAgreeQueryService {
+
     private final TermAgreeRepository termAgreeRepository;
 
     @Override
@@ -22,7 +23,8 @@ public class TermAgreeQueryServiceImpl implements TermAgreeQueryService{
 
         return MemberTermAgreeResponseDTO.builder()
             .memberID(member.getId())
-            .termList(termAgreeList.stream().map(TermAgree::getTerm).map(Term::getTermType).toList())
+            .termList(
+                termAgreeList.stream().map(TermAgree::getTerm).map(Term::getTermType).toList())
             .build();
     }
 }


### PR DESCRIPTION
## 요약
- 약관 관련한 기능 구현했습니다.

## 상세 내용
- Term 엔티티 수정했습니다. 
title -> termType 이넘으로 수정함 (PRIVACY, CONTENT, AGE, COPYRIGHT, SERVICE_CHANGE, MARKETING)

- TermAgree 엔티티 수정했습니다.
approve 삭제. 해당 테이블에는 약정을 수락한 내용만 저장합니다.

API 구현
- 약관 수락
- 약관 삭제
- 멤버의 약관 조회


## 질문 및 이외 사항
약관 수락
<img width="1075" alt="스크린샷 2024-07-24 오후 6 32 11" src="https://github.com/user-attachments/assets/6c517877-cb98-45ba-89e7-7e946d42716d">


약관 삭제

<img width="1079" alt="스크린샷 2024-07-24 오후 6 37 06" src="https://github.com/user-attachments/assets/1ce2f1c7-f043-4d0f-ba7d-c8379336b79c">

약관 목록 조회
<img width="1073" alt="스크린샷 2024-07-24 오후 6 37 19" src="https://github.com/user-attachments/assets/e666e529-044e-458f-a7d5-40c54bc3331b">

-

## 이슈 번호

- #220 