### PR TITLE
Feat : 커뮤니티 글 삭제 시 연관관계 삭제 구현

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandService.java
@@ -1,5 +1,6 @@
 package com.example.dgbackend.domain.combination.service;
 
+import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.combination.dto.CombinationRequest.WriteCombination;
 import com.example.dgbackend.domain.combination.dto.CombinationResponse;
 import com.example.dgbackend.domain.member.Member;
@@ -15,4 +16,6 @@ public interface CombinationCommandService {
         WriteCombination request);
 
     boolean deleteAllCombination(Long memberId);
+
+    void deleteCombinationWithRelations(Combination combination);
 }

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandServiceImpl.java
@@ -79,8 +79,8 @@ public class CombinationCommandServiceImpl implements CombinationCommandService 
 
         Combination combination = combinationQueryService.getCombination(combinationId);
         deleteCombinationWithRelations(combination);
-        //hard delete 로 수정 필요
-        combination.delete();
+        //hard delete
+        combinationRepository.delete(combination);
 
         return CombinationResponse.toCombinationProcResult(combinationId);
     }

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationCommandServiceImpl.java
@@ -6,6 +6,7 @@ import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.combination.dto.CombinationRequest;
 import com.example.dgbackend.domain.combination.dto.CombinationResponse;
 import com.example.dgbackend.domain.combination.repository.CombinationRepository;
+import com.example.dgbackend.domain.combinationcomment.service.CombinationCommentCommandService;
 import com.example.dgbackend.domain.combinationimage.service.CombinationImageCommandService;
 import com.example.dgbackend.domain.combinationimage.service.CombinationImageQueryService;
 import com.example.dgbackend.domain.combinationlike.service.CombinationLikeCommandService;
@@ -38,6 +39,7 @@ public class CombinationCommandServiceImpl implements CombinationCommandService 
     private final CombinationImageQueryService combinationImageQueryService;
     private final CombinationImageCommandService combinationImageCommandService;
     private final MemberRepository memberRepository;
+    private final CombinationCommentCommandService combinationCommentCommandService;
 
     /**
      * 오늘의 조합 작성
@@ -75,8 +77,10 @@ public class CombinationCommandServiceImpl implements CombinationCommandService 
     @Override
     public CombinationResponse.CombinationProcResult deleteCombination(Long combinationId) {
 
-        // soft delete 적용
-        combinationQueryService.getCombination(combinationId).delete();
+        Combination combination = combinationQueryService.getCombination(combinationId);
+        deleteCombinationWithRelations(combination);
+        //hard delete 로 수정 필요
+        combination.delete();
 
         return CombinationResponse.toCombinationProcResult(combinationId);
     }
@@ -119,5 +123,14 @@ public class CombinationCommandServiceImpl implements CombinationCommandService 
             deleteCombination(combination.getId());
         }
         return true;
+    }
+
+    @Override
+    public void deleteCombinationWithRelations(Combination combination) {
+        combinationImageCommandService.deleteAllCombinationImage(combination);
+        combinationLikeCommandService.deleteAllCombinationLike(combination.getId());
+        combinationCommentCommandService.deleteAllCombinationComment(combination);
+        hashTagOptionCommandService.deleteAllHashTagOption(combination.getId());
+
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/repository/CombinationCommentRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/repository/CombinationCommentRepository.java
@@ -1,5 +1,6 @@
 package com.example.dgbackend.domain.combinationcomment.repository;
 
+import com.example.dgbackend.domain.combination.Combination;
 import com.example.dgbackend.domain.combinationcomment.CombinationComment;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -18,4 +19,7 @@ public interface CombinationCommentRepository extends JpaRepository<CombinationC
 
     @Query("SELECT c FROM CombinationComment c WHERE c.id = :id AND c.state = 'TRUE'")
     Optional<CombinationComment> findByIdAndStateTrue(@Param("id") Long id);
+
+    void deleteAllByCombination(Combination combination);
+
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentCommandService.java
@@ -19,4 +19,6 @@ public interface CombinationCommentCommandService {
     CombinationCommentResponse.CommentResult updateComment(Long commentId,
         CombinationCommentRequest.UpdateComment request);
 
+    void deleteAllCombinationComment(Combination combination);
+
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationcomment/service/CombinationCommentCommandServiceImpl.java
@@ -81,4 +81,9 @@ public class CombinationCommentCommandServiceImpl implements CombinationCommentC
         return toCommentResult(combinationComment);
     }
 
+    @Override
+    public void deleteAllCombinationComment(Combination combination) {
+        combinationCommentRepository.deleteAllByCombination(combination);
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationimage/repository/CombinationImageRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationimage/repository/CombinationImageRepository.java
@@ -12,4 +12,6 @@ public interface CombinationImageRepository extends JpaRepository<CombinationIma
     List<CombinationImage> findAllByCombination(Combination combination);
 
     void deleteByImageUrl(String imageUrl);
+
+    void deleteAllByCombination(Combination combination);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationimage/service/CombinationImageCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationimage/service/CombinationImageCommandService.java
@@ -11,4 +11,6 @@ public interface CombinationImageCommandService {
     void updateCombinationImage(Combination combination, List<String> combinationImageList);
 
     CombinationImageResponse.CombinationImageResult uploadImage(List<MultipartFile> multipartFiles);
+
+    void deleteAllCombinationImage(Combination combination);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationimage/service/CombinationImageCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationimage/service/CombinationImageCommandServiceImpl.java
@@ -91,4 +91,22 @@ public class CombinationImageCommandServiceImpl implements CombinationImageComma
 
         combinationImages.forEach(combination::addCombinationImage);
     }
+
+    @Override
+    public void deleteAllCombinationImage(Combination combination) {
+        List<CombinationImage> combinationImages = loadImage(combination.getId());
+
+        List<String> imageUrls = combinationImages.stream()
+            .map(CombinationImage::getImageUrl)
+            .toList();
+
+        imageUrls.forEach(s3Service::deleteFile);
+        combinationImageRepository.deleteAllByCombination(combination);
+
+    }
+
+    private List<CombinationImage> loadImage(Long combinationId) {
+        return combinationImageRepository.findAllByCombinationId(combinationId);
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/repository/CombinationLikeRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/repository/CombinationLikeRepository.java
@@ -13,4 +13,7 @@ public interface CombinationLikeRepository extends JpaRepository<CombinationLike
     boolean existsByCombinationAndMemberAndStateIsTrue(Combination combination, Member member);
 
     Optional<CombinationLike> findByCombinationAndMember(Combination combination, Member member);
+
+    void deleteAllByCombinationId(Long combinationId);
+
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeCommandService.java
@@ -3,4 +3,6 @@ package com.example.dgbackend.domain.combinationlike.service;
 public interface CombinationLikeCommandService {
 
     void deleteCombinationLike(Long combinationId);
+
+    void deleteAllCombinationLike(Long combinationId);
 }

--- a/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combinationlike/service/CombinationLikeCommandServiceImpl.java
@@ -16,4 +16,9 @@ public class CombinationLikeCommandServiceImpl implements CombinationLikeCommand
     public void deleteCombinationLike(Long combinationId) {
         combinationLikeRepository.deleteByCombinationId(combinationId);
     }
+
+    @Override
+    public void deleteAllCombinationLike(Long combinationId) {
+        combinationLikeRepository.deleteAllByCombinationId(combinationId);
+    }
 }

--- a/src/main/java/com/example/dgbackend/domain/hashtagoption/repository/HashTagOptionRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/hashtagoption/repository/HashTagOptionRepository.java
@@ -13,7 +13,7 @@ public interface HashTagOptionRepository extends JpaRepository<HashTagOption, Lo
     List<HashTagOption> findAllByCombinationWithFetch(
         @Param("combination") Combination combination);
 
-    void deleteByCombinationId(Long combinationId);
+    void deleteAllByCombinationId(Long combinationId);
 
     HashTagOption findByCombinationAndHashTagName(Combination combination, String name);
 

--- a/src/main/java/com/example/dgbackend/domain/hashtagoption/service/HashTagOptionCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/hashtagoption/service/HashTagOptionCommandService.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public interface HashTagOptionCommandService {
 
-    void deleteHashTagOption(Long combinationId);
+    void deleteAllHashTagOption(Long combinationId);
 
     void updateHashTagOption(Combination combination, List<String> hashTagNames);
 }

--- a/src/main/java/com/example/dgbackend/domain/hashtagoption/service/HashTagOptionCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/hashtagoption/service/HashTagOptionCommandServiceImpl.java
@@ -22,8 +22,8 @@ public class HashTagOptionCommandServiceImpl implements HashTagOptionCommandServ
     private final HashTagRepository hashTagRepository;
 
     @Override
-    public void deleteHashTagOption(Long combinationId) {
-        hashTagOptionRepository.deleteByCombinationId(combinationId);
+    public void deleteAllHashTagOption(Long combinationId) {
+        hashTagOptionRepository.deleteAllByCombinationId(combinationId);
     }
 
     @Override

--- a/src/main/java/com/example/dgbackend/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/controller/RecipeController.java
@@ -4,7 +4,7 @@ import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.recipe.dto.RecipeRequest;
 import com.example.dgbackend.domain.recipe.dto.RecipeResponse;
 import com.example.dgbackend.domain.recipe.service.RecipeScheduler;
-import com.example.dgbackend.domain.recipe.service.RecipeServiceImpl;
+import com.example.dgbackend.domain.recipe.service.RecipeService;
 import com.example.dgbackend.global.common.response.ApiResponse;
 import com.example.dgbackend.global.jwt.annotation.MemberObject;
 import com.example.dgbackend.global.validation.annotation.CheckPage;
@@ -29,15 +29,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class RecipeController {
 
-	private final RecipeServiceImpl recipeServiceImpl;
-	private final RecipeScheduler recipeScheduler;
+    private final RecipeService recipeService;
+    private final RecipeScheduler recipeScheduler;
 
     @Operation(summary = "모든 레시피북 조회", description = "삭제되지 않은 레시피북 목록을 조회합니다.")
     @Parameter(name = "page", description = "페이지 번호, Query Param 입니다.", required = true, example = "0", in = ParameterIn.QUERY)
     @GetMapping
     public ApiResponse<RecipeResponse.RecipeResponseList> getRecipes(@RequestParam("page") int page,
         @Parameter(hidden = true) @MemberObject Member loginMember) {
-        return ApiResponse.onSuccess(recipeServiceImpl.getExistRecipes(page, loginMember));
+        return ApiResponse.onSuccess(recipeService.getExistRecipes(page, loginMember));
     }
 
     @Operation(summary = "레시피북 상세정보 조회", description = "특정 레시피북 정보를 조회합니다.")
@@ -45,14 +45,14 @@ public class RecipeController {
     @GetMapping("/{recipeId}")
     public ApiResponse<RecipeResponse> getRecipe(@PathVariable Long recipeId,
         @Parameter(hidden = true) @MemberObject Member loginMember) {
-        return ApiResponse.onSuccess(recipeServiceImpl.getRecipeDetail(recipeId, loginMember));
+        return ApiResponse.onSuccess(recipeService.getRecipeDetail(recipeId, loginMember));
     }
 
     @Operation(summary = "레시피북 등록", description = "레시피북을 등록합니다.")
     @PostMapping
     public ApiResponse<RecipeResponse> createRecipe(@RequestBody RecipeRequest recipeRequest,
         @Parameter(hidden = true) @MemberObject Member loginMember) {
-        return ApiResponse.onSuccess(recipeServiceImpl.createRecipe(recipeRequest, loginMember));
+        return ApiResponse.onSuccess(recipeService.createRecipe(recipeRequest, loginMember));
     }
 
     @Operation(summary = "레시피북 수정", description = "레시피북을 수정합니다.")
@@ -62,7 +62,7 @@ public class RecipeController {
         @RequestBody RecipeRequest recipeRequest,
         @Parameter(hidden = true) @MemberObject Member loginMember) {
         return ApiResponse.onSuccess(
-            recipeServiceImpl.updateRecipe(recipeId, recipeRequest, loginMember));
+            recipeService.updateRecipe(recipeId, recipeRequest, loginMember));
     }
 
     @Operation(summary = "레시피북 삭제", description = "레시피북을 삭제합니다.")
@@ -70,7 +70,7 @@ public class RecipeController {
     @DeleteMapping("/{recipeId}")
     public ApiResponse<String> deleteRecipe(@PathVariable Long recipeId,
         @Parameter(hidden = true) @MemberObject Member loginMember) {
-        return ApiResponse.onSuccess(recipeServiceImpl.deleteRecipe(recipeId, loginMember));
+        return ApiResponse.onSuccess(recipeService.deleteRecipe(recipeId, loginMember));
     }
 
     @Operation(summary = "내가 작성한 레시피북 조회", description = "특정 회원의 레시피북 목록을 조회합니다.")
@@ -79,7 +79,7 @@ public class RecipeController {
     public ApiResponse<RecipeResponse.RecipeMyPageList> getMyPageList(
         @Parameter(hidden = true) @MemberObject Member loginMember,
         @CheckPage @RequestParam(name = "page") Integer page) {
-        return ApiResponse.onSuccess(recipeServiceImpl.getRecipeMyPageList(loginMember, page));
+        return ApiResponse.onSuccess(recipeService.getRecipeMyPageList(loginMember, page));
     }
 
     @Operation(summary = "내가 좋아요한 레시피북 조회", description = "좋아요를 누른 레시피북 목록을 조회합니다.")
@@ -88,7 +88,7 @@ public class RecipeController {
     public ApiResponse<RecipeResponse.RecipeMyPageList> getLikeList(
         @Parameter(hidden = true) @MemberObject Member loginMember,
         @CheckPage @RequestParam(name = "page") Integer page) {
-        return ApiResponse.onSuccess(recipeServiceImpl.getRecipeLikeList(loginMember, page));
+        return ApiResponse.onSuccess(recipeService.getRecipeLikeList(loginMember, page));
     }
 
     @Operation(summary = "레시피북 검색", description = "레시피북 목록을 검색합니다.")
@@ -97,7 +97,7 @@ public class RecipeController {
         @RequestParam(value = "page") Integer page, @RequestParam(value = "keyword") String keyword,
         @Parameter(hidden = true) @MemberObject Member loginMember) {
         return ApiResponse.onSuccess(
-            recipeServiceImpl.findRecipesByKeyword(page, keyword, loginMember));
+            recipeService.findRecipesByKeyword(page, keyword, loginMember));
     }
 
     @Operation(summary = "메인 레시피북 조회", description = "메인에 띄울 레시피북을 조회합니다.")

--- a/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeService.java
@@ -10,7 +10,7 @@ public interface RecipeService {
     RecipeResponse.RecipeResponseList getExistRecipes(int page, Member loginMember);
 
 
-	RecipeResponse getRecipeDetail(Long id, Member member);
+    RecipeResponse getRecipeDetail(Long id, Member member);
 
     RecipeResponse createRecipe(RecipeRequest recipeRequest, Member loginMember);
 
@@ -19,13 +19,13 @@ public interface RecipeService {
     String deleteRecipe(Long id, Member loginMember);
 
 
-	//레시피 이름과 회원 이름으로 레시피 탐색
-	Recipe getRecipe(Long id);
+    //레시피 이름과 회원 이름으로 레시피 탐색
+    Recipe getRecipe(Long id);
 
-	//레시피가 삭제된 경우 예외처리
-	Recipe isDelete(Recipe recipe);
+    //레시피가 삭제된 경우 예외처리
+    Recipe isDelete(Recipe recipe);
 
-	void isAlreadyCreate(String RecipeName, String memberName);
+    void isAlreadyCreate(String RecipeName, String memberName);
 
     RecipeResponse.RecipeMyPageList getRecipeMyPageList(Member loginMember, Integer Page);
 
@@ -36,5 +36,5 @@ public interface RecipeService {
 
     RecipeResponse getRecipeDetailResponse(Recipe recipes, Member loginMember);
 
-
+    void deleteRecipeWithRelations(Recipe recipe);
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
@@ -10,6 +10,8 @@ import com.example.dgbackend.domain.recipe.dto.RecipeResponse;
 import com.example.dgbackend.domain.recipe.repository.RecipeRepository;
 import com.example.dgbackend.domain.recipe_hashtag.RecipeHashTag;
 import com.example.dgbackend.domain.recipe_hashtag.service.RecipeHashTagService;
+import com.example.dgbackend.domain.recipecomment.service.RecipeCommentService;
+import com.example.dgbackend.domain.recipeimage.service.RecipeImageService;
 import com.example.dgbackend.domain.recipelike.service.RecipeLikeService;
 import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
 import com.example.dgbackend.global.exception.ApiException;
@@ -31,6 +33,8 @@ public class RecipeServiceImpl implements RecipeService {
     private final RecipeRepository recipeRepository;
     private final RecipeHashTagService recipeHashTagService;
     private final RecipeLikeService recipeLikeService;
+    private final RecipeImageService recipeImageService;
+    private final RecipeCommentService recipeCommentService;
 
     @Override
     public RecipeResponse.RecipeResponseList getExistRecipes(int page, Member member) {
@@ -102,8 +106,9 @@ public class RecipeServiceImpl implements RecipeService {
         Recipe recipe = getRecipe(id);
 
         if (isMatch(loginMember, recipe.getMember())) {
+            deleteRecipeWithRelations(recipe);
+            //hard delete 수정 필요
             recipe.delete();
-            recipeHashTagService.deleteRecipeHashTag(id);
             return "삭제 완료";
         } else {
             throw new ApiException(ErrorStatus._INVALID_MEMBER);
@@ -181,5 +186,13 @@ public class RecipeServiceImpl implements RecipeService {
     private void isBlocked(Long recipeId, Long memberId) {
         Recipe blockedRecipe = recipeRepository.findByIdAndMemberAndStateIsTrue(recipeId, memberId)
             .orElseThrow(() -> new ApiException(ErrorStatus._BLOCKED_MEMBER));
+    }
+
+    @Override
+    public void deleteRecipeWithRelations(Recipe recipe) {
+        recipeImageService.deleteRecipeImage(recipe);
+        recipeLikeService.deleteAllRecipeLike(recipe.getId());
+        recipeCommentService.deleteAllRecipeComment(recipe);
+        recipeHashTagService.deleteAllRecipeHashTag(recipe);
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
@@ -107,15 +107,15 @@ public class RecipeServiceImpl implements RecipeService {
 
         if (isMatch(loginMember, recipe.getMember())) {
             deleteRecipeWithRelations(recipe);
-            //hard delete 수정 필요
-            recipe.delete();
+            //hard delete
+            recipeRepository.delete(recipe);
             return "삭제 완료";
         } else {
             throw new ApiException(ErrorStatus._INVALID_MEMBER);
         }
     }
 
-    //레시피 이름과 회원 이름으로 레시피 탐색
+    //레시피 id로 레시피 탐색
     @Override
     public Recipe getRecipe(Long id) {
 

--- a/src/main/java/com/example/dgbackend/domain/recipe_hashtag/RecipeHashTag.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe_hashtag/RecipeHashTag.java
@@ -2,6 +2,7 @@ package com.example.dgbackend.domain.recipe_hashtag;
 
 import com.example.dgbackend.domain.hashtag.HashTag;
 import com.example.dgbackend.domain.recipe.Recipe;
+import com.example.dgbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class RecipeHashTag {
+public class RecipeHashTag extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/dgbackend/domain/recipe_hashtag/repository/RecipeHashTagRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe_hashtag/repository/RecipeHashTagRepository.java
@@ -10,4 +10,6 @@ public interface RecipeHashTagRepository extends JpaRepository<RecipeHashTag, Lo
 
     void deleteByRecipe_Id(Long recipeId);
 
+    void deleteAllByRecipeId(Long recipeId);
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagService.java
@@ -10,4 +10,6 @@ public interface RecipeHashTagService {
 
     void deleteRecipeHashTag(Long recipeId);
 
+    void deleteAllRecipeHashTag(Recipe recipe);
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe_hashtag/service/RecipeHashTagServiceImpl.java
@@ -46,4 +46,11 @@ public class RecipeHashTagServiceImpl implements RecipeHashTagService {
         recipeHashTagRepository.deleteByRecipe_Id(recipeId);
     }
 
+    @Override
+    @Transactional
+    public void deleteAllRecipeHashTag(Recipe recipe) {
+        recipeHashTagRepository.deleteAllByRecipeId(recipe.getId());
+
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/controller/RecipeCommentController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/controller/RecipeCommentController.java
@@ -4,7 +4,7 @@ import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentRequest;
 import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentResponse;
 import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentVO;
-import com.example.dgbackend.domain.recipecomment.service.RecipeCommentServiceImpl;
+import com.example.dgbackend.domain.recipecomment.service.RecipeCommentService;
 import com.example.dgbackend.global.common.response.ApiResponse;
 import com.example.dgbackend.global.jwt.annotation.MemberObject;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/recipe-comments")
 public class RecipeCommentController {
 
-    private final RecipeCommentServiceImpl recipeCommentService;
+    private final RecipeCommentService recipeCommentService;
 
     @Operation(summary = "레시피북 댓글 조회", description = "특정 레시피북의 댓글을 조회합니다.")
     @Parameter(name = "recipeId", description = "레시피북 Id, Path Variable 입니다.", required = true, example = "1", in = ParameterIn.PATH)

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/repository/RecipeCommentRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/repository/RecipeCommentRepository.java
@@ -24,4 +24,6 @@ public interface RecipeCommentRepository extends JpaRepository<RecipeComment, Lo
 
     @Query("SELECT r FROM RecipeComment r WHERE r.id = :id AND r.state = 'TRUE'")
     Optional<RecipeComment> findByIdAndStateTrue(@Param("id") Long id);
+
+    void deleteAllByRecipe(Recipe recipe);
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentService.java
@@ -1,6 +1,7 @@
 package com.example.dgbackend.domain.recipecomment.service;
 
 import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.recipe.Recipe;
 import com.example.dgbackend.domain.recipecomment.RecipeComment;
 import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentRequest;
 import com.example.dgbackend.domain.recipecomment.dto.RecipeCommentResponse;
@@ -23,4 +24,6 @@ public interface RecipeCommentService {
         Member loginMember);
 
     RecipeCommentResponse deleteRecipeComment(Long recipeCommentId, Member loginMember);
+
+    void deleteAllRecipeComment(Recipe recipe);
 }

--- a/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipecomment/service/RecipeCommentServiceImpl.java
@@ -118,4 +118,10 @@ public class RecipeCommentServiceImpl implements RecipeCommentService {
         }
 
     }
+
+    @Override
+    @Transactional
+    public void deleteAllRecipeComment(Recipe recipe) {
+        recipeCommentRepository.deleteAllByRecipe(recipe);
+    }
 }

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/controller/RecipeImageController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/controller/RecipeImageController.java
@@ -4,7 +4,6 @@ import com.example.dgbackend.domain.recipeimage.dto.RecipeImageResponse;
 import com.example.dgbackend.domain.recipeimage.dto.RecipeImageVO;
 import com.example.dgbackend.domain.recipeimage.service.RecipeImageService;
 import com.example.dgbackend.global.common.response.ApiResponse;
-import com.example.dgbackend.global.s3.S3Service;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/controller/RecipeImageController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/controller/RecipeImageController.java
@@ -29,7 +29,6 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/recipe-images")
 public class RecipeImageController {
 
-    private final S3Service s3Service;
     private final RecipeImageService recipeImageService;
 
     @Operation(summary = "레시피 이미지 조회", description = "레시피 이미지 조회")

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/repository/RecipeImageRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/repository/RecipeImageRepository.java
@@ -13,4 +13,6 @@ public interface RecipeImageRepository extends JpaRepository<RecipeImage, Long> 
     List<RecipeImage> findAllByRecipe(Recipe recipe);
 
     Optional<RecipeImage> findByImageUrl(String imageUrl);
+
+    void deleteAllByRecipe(Recipe recipe);
 }

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
@@ -110,4 +110,21 @@ public class RecipeImageService {
         });
     }
 
+    public void deleteRecipeImage(Recipe recipe) {
+        List<RecipeImage> recipeImages = loadImage(recipe.getId());
+
+        List<String> imageUrls = recipeImages.stream()
+            .map(RecipeImage::getImageUrl)
+            .toList();
+
+        imageUrls.forEach(s3Service::deleteFile);
+        recipeImageRepository.deleteAllByRecipe(recipe);
+
+    }
+
+    private List<RecipeImage> loadImage(Long recipeId) {
+        return recipeImageRepository.findAllByRecipeId(recipeId);
+    }
+
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipelike/controller/RecipeLikeController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipelike/controller/RecipeLikeController.java
@@ -2,6 +2,7 @@ package com.example.dgbackend.domain.recipelike.controller;
 
 import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.recipelike.dto.RecipeLikeResponse;
+import com.example.dgbackend.domain.recipelike.service.RecipeLikeService;
 import com.example.dgbackend.domain.recipelike.service.RecipeLikeServiceImpl;
 import com.example.dgbackend.global.common.response.ApiResponse;
 import com.example.dgbackend.global.jwt.annotation.MemberObject;
@@ -23,14 +24,14 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class RecipeLikeController {
 
-    private final RecipeLikeServiceImpl recipeLikeServiceImpl;
+    private final RecipeLikeService recipeLikeService;
 
     @Operation(summary = "레시피북 좋아요 조회", description = "특정 레시피북의 좋아요를 조회합니다.")
     @Parameter(name = "recipeId", description = "레시피북 Id, Path Variable 입니다.", required = true, example = "1")
     @GetMapping("/{recipeId}")
     public ApiResponse<RecipeLikeResponse> getRecipeLikes(@PathVariable Long recipeId,
         @MemberObject Member member) {
-        return ApiResponse.onSuccess(recipeLikeServiceImpl.getRecipeLike(recipeId, member));
+        return ApiResponse.onSuccess(recipeLikeService.getRecipeLike(recipeId, member));
     }
 
     @Operation(summary = "레시피북 좋아요 등록", description = "레시피북 좋아요를 등록합니다.")
@@ -38,7 +39,7 @@ public class RecipeLikeController {
     @PostMapping("/{recipeId}")
     public ApiResponse<RecipeLikeResponse> createRecipeLike(@PathVariable Long recipeId,
         @MemberObject Member member) {
-        return ApiResponse.onSuccess(recipeLikeServiceImpl.changeRecipeLike(recipeId, member));
+        return ApiResponse.onSuccess(recipeLikeService.changeRecipeLike(recipeId, member));
     }
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipelike/repository/RecipeLikeRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipelike/repository/RecipeLikeRepository.java
@@ -9,4 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RecipeLikeRepository extends JpaRepository<RecipeLike, Long> {
 
     Optional<RecipeLike> findByRecipeAndMember(Recipe recipe, Member member);
+
+    void deleteAllByRecipeId(Long recipeId);
 }

--- a/src/main/java/com/example/dgbackend/domain/recipelike/service/RecipeLikeService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipelike/service/RecipeLikeService.java
@@ -14,4 +14,6 @@ public interface RecipeLikeService {
     RecipeLike createRecipe(Long recipeId, Member member);
 
     Optional<RecipeLike> getRecipeLikeEntity(Long recipeId, Member member);
+
+    void deleteAllRecipeLike(Long recipeId);
 }

--- a/src/main/java/com/example/dgbackend/domain/recipelike/service/RecipeLikeServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipelike/service/RecipeLikeServiceImpl.java
@@ -65,4 +65,10 @@ public class RecipeLikeServiceImpl implements RecipeLikeService {
             .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE));
         return recipeLikeRepository.findByRecipeAndMember(recipe, member);
     }
+
+    @Override
+    public void deleteAllRecipeLike(Long recipeId) {
+        recipeLikeRepository.deleteAllByRecipeId(recipeId);
+
+    }
 }


### PR DESCRIPTION
## 요약

- 커뮤니티 글 삭제 시 연관관계 삭제 구현를 구현하였습니다.
- 모두 hard delete 로 수정 및 구현하였습니다.

## 상세 내용

- Combination 도메인 : `deleteCombinationWithRelations`
- Recipe 도메인 : `deleteRecipeWithRelations`

에서 해당 연관 관계 삭제 기능을 구현하였습니다.

- 각각 이미지, 좋아요, 댓글, 해시태그를 삭제합니다.
- 이미지 삭제 시, S3에서 먼저 삭제 후 DB에서 삭제하도록 하였습니다.
- 구현 중 `RecipeService` <-> `RecipeImageService` 간의 순환 참조가 발생하여, `RecipeImageService` 에서 RecipeService가 아닌 `RecipeRepository` 를 참조하도록 변경하여 단방향 계층으로 구현하였습니다.

또한 Recipe 도메인 Controller에서 인터페이스를 사용하도록 수정하였습니다!

## 질문 및 이외 사항

- 해시태그는 연관 관계 테이블만 삭제하도록 하였습니다.
- 테스트 완료하였습니다! 더 좋은 구현 방법이나 수정이 필요한 부분 언제든지 말씀해주시면 감사하겠습니다.

## 이슈 번호

- close #212 