### PR TITLE
Feat: 해시태그를 통한 검색 기능 추가

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/repository/CombinationRepository.java
@@ -31,13 +31,23 @@ public interface CombinationRepository extends JpaRepository<Combination, Long> 
         PageRequest pageRequest);
 
 
-    @Query("SELECT c FROM Combination c WHERE c.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND c.title LIKE %:keyword% AND c.state = true ORDER BY c.createdAt DESC")
-    Page<Combination> findCombinationsByTitleContainingAndStateIsTrueOrderByCreatedAtDesc(
+    @Query("SELECT c FROM Combination c "
+        + "WHERE c.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) "
+        + "AND (c.title LIKE %:keyword% "
+        + "OR c.content LIKE %:keyword% "
+        + "OR c.id IN (SELECT hto.combination.id FROM HashTagOption hto WHERE hto.hashTag.name LIKE %:keyword%)) "
+        + "AND c.state = true ORDER BY c.createdAt DESC")
+    Page<Combination> findCombinationsByTitleOrContentOrHashTagAndStateIsTrueOrderByCreatedAtDesc(
         String keyword, PageRequest pageRequest, Long memberId);
 
 
-    @Query("SELECT c FROM Combination c WHERE c.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND c.title LIKE %:keyword% AND c.likeCount >= :likeCount AND c.state = true ORDER BY c.createdAt DESC")
-    Page<Combination> findCombinationsByTitleContainingAndLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
+    @Query("SELECT c FROM Combination c "
+        + "WHERE c.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) "
+        + "AND (c.title LIKE %:keyword% "
+        + "OR c.content LIKE %:keyword% "
+        + "OR c.id IN (SELECT hto.combination.id FROM HashTagOption hto WHERE hto.hashTag.name LIKE %:keyword%)) "
+        + "AND c.likeCount >= :likeCount AND c.state = true ORDER BY c.createdAt DESC")
+    Page<Combination> findCombinationsByTitleOrContentOrHashTagAndLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
         String keyword, PageRequest pageRequest, Long likeCount, Long memberId);
 
     @Query("SELECT c FROM Combination c WHERE c.likeCount >= 30 AND c.state = true ORDER BY RAND() LIMIT 5")

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationQueryServiceImpl.java
@@ -196,7 +196,7 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
         String keyword) {
         PageRequest pageRequest = PageRequest.of(page, 10);
 
-        Page<Combination> combinations = combinationRepository.findCombinationsByTitleContainingAndStateIsTrueOrderByCreatedAtDesc(
+        Page<Combination> combinations = combinationRepository.findCombinationsByTitleOrContentOrHashTagAndStateIsTrueOrderByCreatedAtDesc(
             keyword, pageRequest, loginMember.getId());
 
         List<Combination> combinationList = combinations.getContent();
@@ -217,7 +217,7 @@ public class CombinationQueryServiceImpl implements CombinationQueryService {
         String keyword) {
         PageRequest pageRequest = PageRequest.of(page, 10);
 
-        Page<Combination> combinations = combinationRepository.findCombinationsByTitleContainingAndLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
+        Page<Combination> combinations = combinationRepository.findCombinationsByTitleOrContentOrHashTagAndLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
             keyword, pageRequest, 30L, loginMember.getId());
 
         List<Combination> combinationList = combinations.getContent();

--- a/src/main/java/com/example/dgbackend/domain/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/repository/RecipeRepository.java
@@ -23,8 +23,12 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
     @Query("SELECT rl.recipe FROM RecipeLike rl WHERE rl.member.id = :memberId AND rl.recipe.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND rl.recipe.state = true AND rl.state = true")
     Page<Recipe> findRecipesByMemberIdAndStateIsTrue(Long memberId, PageRequest pageRequest);
 
-    @Query("SELECT r FROM Recipe r WHERE r.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) AND r.title LIKE %:keyword% AND r.state = true ORDER BY r.createdAt DESC")
-    Page<Recipe> findRecipesByTitleContainingAndStateIsTrueOrderByCreatedAtDesc(String keyword,
+    @Query("SELECT r FROM Recipe r "
+        + "WHERE r.member NOT IN (SELECT mb.blockedMember FROM MemberBlock mb WHERE mb.member.id = :memberId) "
+        + "AND (r.title LIKE %:keyword% "
+        + "OR r.id IN (SELECT rht.recipe.id FROM RecipeHashTag rht WHERE rht.hashtag.name LIKE %:keyword%)) "
+        + "AND r.state = true ORDER BY r.createdAt DESC")
+    Page<Recipe> findRecipesByTitleOrHashTagAndStateIsTrueOrderByCreatedAtDesc(String keyword,
         Pageable pageable, Long memberId);
 
     Page<Recipe> findAllByStateIsTrueOrderByLikeCountDesc(PageRequest pageRequest);

--- a/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
@@ -153,9 +153,8 @@ public class RecipeServiceImpl implements RecipeService {
 
         Pageable pageable = Pageable.ofSize(10).withPage(page);
 
-        Page<Recipe> recipesByKeyword = recipeRepository.findRecipesByTitleContainingAndStateIsTrueOrderByCreatedAtDesc(
-            keyword, pageable,
-            member.getId());
+        Page<Recipe> recipesByKeyword = recipeRepository.findRecipesByTitleOrHashTagAndStateIsTrueOrderByCreatedAtDesc(
+            keyword, pageable, member.getId());
 
         List<RecipeResponse> recipeResponseList = recipesByKeyword.getContent().stream()
             .map(recipe -> {


### PR DESCRIPTION
## 요약

- 기존 검색 API를 해시태그 및 내용을 통해 검색할 수 있도록 기능을 추가합니다.

## 상세 내용

- 오늘의 조합, 주간 베스트 조합 검색 API 해시태그 검색 기능 추가
- 오늘의 조합, 주간 베스트 조합 검색 API 내용 검색 기능 추가
- 레시피북 검색 API 해시태그 검색 기능 추가
- 해당 기능 모두 쿼리문 수정을 통해 구현하였습니다.
- `LEFT JOIN`과 `IN` 방식 중 테스트해보았지만 현재는 쿼리문 차이가 없어, `IN` 절의 서브 쿼리가 더 적으므로 IN 구문을 사용하여 추후 더 많은 데이터 조회시에도 효율적으로 조회할 수 있도록 `IN` 절을 사용하였습니다.

![image](https://github.com/user-attachments/assets/b6f8f57b-90c3-4198-b328-74df261261a5)

`요아정` 이라는 해시태그를 검색 했을 때, 해당 해시태그가 존재하는 게시글이 검색되는 모습을 확인할 수 있습니다.

## 질문 및 이외 사항

- Combination은 제목 + 내용 + 해시태그로 검색합니다.
- 레시피북은 PM과 상의하여 제목 + 해시태그로만 검색하도록 하였습니다.
- 클라이언트측에서 글을 작성할 때, 해시태그에 #이 붙어서 저장될 때가 있고 아닐 때가 있는 것 같아 추후 확인하여 프론트측에서 수정이 이루어진다면 데이터베이스가 깔끔하게 보일 것 같습니다!

## 이슈 번호

- close #227 