### PR TITLE
Refactor: 오늘의 조합 상세조회 Response 수정

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/dto/CombinationResponse.java
@@ -5,6 +5,8 @@ import com.example.dgbackend.domain.combinationcomment.dto.CombinationCommentRes
 import com.example.dgbackend.domain.combinationimage.CombinationImage;
 import com.example.dgbackend.domain.hashtagoption.HashTagOption;
 import com.example.dgbackend.domain.member.dto.MemberResponse;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -223,6 +225,7 @@ public class CombinationResponse {
         CombinationResult combinationResult,
         MemberResponse.MemberResult memberResult,
         CombinationCommentResponse.CommentPreViewResult combinationCommentResult) {
+
         return CombinationDetailResult.builder()
             .combinationResult(combinationResult)
             .memberResult(memberResult)
@@ -234,6 +237,7 @@ public class CombinationResponse {
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
+    @JsonInclude(Include.NON_NULL) // null 값이 아닐 때만 반환
     public static class CombinationResult {
 
         Long combinationId;
@@ -242,6 +246,7 @@ public class CombinationResponse {
         List<String> hashTagList;
         List<String> combinationImageList;
         Boolean isCombinationLike;
+        Long recommendId;
     }
 
     public static CombinationResult toCombinationResult(Combination combination,
@@ -262,8 +267,10 @@ public class CombinationResponse {
             .hashTagList(hashTagList)
             .combinationImageList(imageList)
             .isCombinationLike(isCombinationLike)
+            .recommendId(combination.getRecommend() != null ? combination.getRecommend().getId() : null)
             .build();
     }
+
 
     /**
      * 오늘의 조합 수정 정보 조회


### PR DESCRIPTION
## 요약

- 오늘의 조합 상세정보 조회 시, recommnendId가 null 값이 아닌 경우 반환

## 상세 내용

 @JsonInclude(Include.NON_NULL) 어노테이션을 통해 구현

- recommendId가 있을 경우
<img width="1412" alt="스크린샷 2024-08-27 오후 6 07 41" src="https://github.com/user-attachments/assets/2c376a46-6d23-4109-81e7-8098f2335b7a">

- recommendId가 없을 경우
<img width="1427" alt="스크린샷 2024-08-27 오후 6 07 25" src="https://github.com/user-attachments/assets/b26007aa-c97b-4ded-85dd-23953e4b6f90">


## 질문 및 이외 사항

-  

## 이슈 번호

- #237