### PR TITLE
[CHANGE] 레시피 이미지 업로드 방식 수정

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/recipe/Recipe.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/Recipe.java
@@ -113,4 +113,9 @@ public class Recipe extends BaseTimeEntity {
         this.recipeHashTagList = new HashSet<>(recipeHashTagList);
     }
 
+    public void addRecipeImage(RecipeImage recipeImage) {
+        recipeImageList.add(recipeImage);
+        recipeImage.setRecipe(this);
+    }
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe/dto/RecipeRequest.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/dto/RecipeRequest.java
@@ -2,6 +2,7 @@ package com.example.dgbackend.domain.recipe.dto;
 
 import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.recipe.Recipe;
+import com.example.dgbackend.domain.recipeimage.RecipeImage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -42,8 +43,11 @@ public class RecipeRequest {
     @Schema(description = "해시태그 리스트", example = "[\"김치찌개\", \"참이슬\"]")
     private List<String> hashTagNameList;
 
+    @Schema(description = "레시피 이미지 url 리스트", example = "[\"https://d3h9ln6psucegz.cloudfront.net/images/recipe/recipe_1/recipe_1_1.jpg\"]")
+    private List<String> recipeImageList;
+
     public static Recipe toEntity(RecipeRequest recipeRequest, Member member) {
-        return Recipe.builder()
+        Recipe recipe = Recipe.builder()
             .title(recipeRequest.getTitle())
             .cookingTime(recipeRequest.getCookingTime())
             .calorie(recipeRequest.getCalorie())
@@ -54,6 +58,15 @@ public class RecipeRequest {
             .recommendCombination(recipeRequest.getRecommendCombination())
             .member(member)
             .build();
+
+        for (String imageUrl : recipeRequest.getRecipeImageList()) {
+            RecipeImage recipeImage = RecipeImage.builder()
+                .imageUrl(imageUrl)
+                .build();
+            recipe.addRecipeImage(recipeImage);
+        }
+        return recipe;
     }
+
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipe/dto/RecipeResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/dto/RecipeResponse.java
@@ -4,7 +4,6 @@ import com.example.dgbackend.domain.member.dto.MemberResponse;
 import com.example.dgbackend.domain.recipe.Recipe;
 import com.example.dgbackend.domain.recipe_hashtag.dto.RecipeHashTagResponse;
 import com.example.dgbackend.domain.recipeimage.RecipeImage;
-import com.example.dgbackend.domain.recipeimage.dto.RecipeImageResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -99,6 +98,11 @@ public class RecipeResponse {
     }
 
     public static RecipeResponse toResponse(Recipe recipe, boolean isLike) {
+
+        List<String> iamgeList = recipe.getRecipeImageList().stream()
+            .map(RecipeImage::getImageUrl)
+            .toList();
+
         return RecipeResponse.builder()
             .id(recipe.getId())
             .title(recipe.getTitle())
@@ -111,7 +115,7 @@ public class RecipeResponse {
             .recommendCombination(recipe.getRecommendCombination())
             .state(recipe.isState())
             .member(MemberResponse.toMemberResult(recipe.getMember()))
-            .recipeImageList(RecipeImageResponse.toStringResponse(recipe.getRecipeImageList()))
+            .recipeImageList(iamgeList)
             .hashTagNameList(RecipeHashTagResponse.toStringResponse(recipe.getRecipeHashTagList()))
             .isLike(isLike)
             .build();

--- a/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/service/RecipeServiceImpl.java
@@ -16,7 +16,6 @@ import com.example.dgbackend.domain.recipeimage.service.RecipeImageService;
 import com.example.dgbackend.domain.recipelike.service.RecipeLikeService;
 import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
 import com.example.dgbackend.global.exception.ApiException;
-
 import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -97,6 +96,7 @@ public class RecipeServiceImpl implements RecipeService {
             List<RecipeHashTag> hashTags = recipeHashTagService.uploadRecipeHashTag(recipe,
                 recipeRequest.getHashTagNameList());
             recipe.setHashTagList(hashTags);
+            recipeImageService.updateRecipeImage(recipe, recipeRequest.getRecipeImageList());
             return getRecipeDetailResponse(recipe.update(recipeRequest), recipe.getMember());
         } else {
             throw new ApiException(ErrorStatus._INVALID_MEMBER);

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/RecipeImage.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/RecipeImage.java
@@ -34,4 +34,7 @@ public class RecipeImage extends BaseTimeEntity {
     @JoinColumn(name = "recipe_id")
     private Recipe recipe;
 
+    public void setRecipe(Recipe recipe) {
+        this.recipe = recipe;
+    }
 }

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/controller/RecipeImageController.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/controller/RecipeImageController.java
@@ -1,7 +1,6 @@
 package com.example.dgbackend.domain.recipeimage.controller;
 
 import com.example.dgbackend.domain.recipeimage.dto.RecipeImageResponse;
-import com.example.dgbackend.domain.recipeimage.dto.RecipeImageVO;
 import com.example.dgbackend.domain.recipeimage.service.RecipeImageService;
 import com.example.dgbackend.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,7 +12,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -37,38 +35,20 @@ public class RecipeImageController {
         return ApiResponse.onSuccess(recipeImageService.getRecipeImages(recipeId));
     }
 
-    @Operation(summary = "레시피 이미지 생성", description = "레시피 이미지 생성")
-    @Parameter(name = "file", description = "파일", required = true)
-    @Parameter(name = "recipeId", description = "레시피 id", required = true)
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ApiResponse<RecipeImageResponse> createRecipeImage(
-        @RequestPart("file") List<MultipartFile> file, @RequestParam("recipeId") Long recipeId) {
-
-        //파일과 레시피 id로 RecipeImageVO.FileRecipe 생성
-        RecipeImageVO.FileVO recipeImageRequestVO = RecipeImageVO.FileVO.of(file, recipeId, null);
-        return ApiResponse.onSuccess(recipeImageService.createRecipeImage(recipeImageRequestVO));
-    }
-
-    @Operation(summary = "레시피 이미지 수정", description = "레시피 이미지 수정")
-    @Parameter(name = "recipeId", description = "레시피 id", required = true)
-    @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ApiResponse<RecipeImageResponse> updateRecipeImage(
-        @RequestPart(value = "file", required = false) @Parameter(name = "file", description = "파일", required = false) List<MultipartFile> file,
-        @RequestPart(value = "deleteList", required = false) @Parameter(name = "deleteList", description = "삭제할 파일 url 리스트", required = false) List<String> deleteFileUrlStringList,
-        @RequestParam("recipeId") Long recipeId) {
-
-        //파일과 레시피 id, 삭제할 파일 url 리스트로 RecipeImageVO.FileRecipe 생성
-        RecipeImageVO.FileVO recipeImageRequestVO = RecipeImageVO.FileVO.of(file, recipeId,
-            deleteFileUrlStringList);
-        return ApiResponse.onSuccess(recipeImageService.updateRecipeImage(recipeImageRequestVO));
-    }
-
     @Operation
     @Parameter(name = "recipeId", description = "레시피 id", required = true)
     @DeleteMapping
     public ApiResponse<String> deleteRecipeImage(@RequestParam("recipeId") Long recipeId) {
         recipeImageService.deleteAllRecipeImage(recipeId);
         return ApiResponse.onSuccess("삭제 성공");
+    }
+
+    @Operation(summary = "레시피 이미지 업로드", description = "레시피 이미지 업로드")
+    @Parameter(name = "file", description = "파일", required = true)
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<RecipeImageResponse.RecipeImageResult> uploadRecipeImage(
+        @RequestPart(name = "imageUrls", required = false) List<MultipartFile> multipartFiles) {
+        return ApiResponse.onSuccess(recipeImageService.uploadRecipeImage(multipartFiles));
     }
 
 }

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/dto/RecipeImageResponse.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/dto/RecipeImageResponse.java
@@ -1,34 +1,26 @@
 package com.example.dgbackend.domain.recipeimage.dto;
 
-import com.example.dgbackend.domain.recipe.Recipe;
-import com.example.dgbackend.domain.recipeimage.RecipeImage;
-import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class RecipeImageResponse {
 
 
-    @Schema(description = "레시피 이미지 url 리스트", example = "[\"https://d3h9ln6psucegz.cloudfront.net/images/recipe/recipe_1/recipe_1_1.jpg\"]")
-    private List<String> imageUrlList;
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class RecipeImageResult {
 
-    public static RecipeImageResponse toURLResponse(Recipe recipe) {
-        return RecipeImageResponse.builder()
-            .imageUrlList(RecipeImageResponse.toStringResponse(recipe.getRecipeImageList()))
+        List<String> recipeImageList;
+    }
+
+    public static RecipeImageResult toRecipeImageResult(List<String> imageUrls) {
+        return RecipeImageResult.builder()
+            .recipeImageList(imageUrls)
             .build();
     }
-
-    public static List<String> toStringResponse(List<RecipeImage> recipeList) {
-        return recipeList.stream()
-            .map(RecipeImage::getImageUrl)
-            .toList();
-    }
-
 }

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/repository/RecipeImageRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/repository/RecipeImageRepository.java
@@ -5,6 +5,8 @@ import com.example.dgbackend.domain.recipeimage.RecipeImage;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface RecipeImageRepository extends JpaRepository<RecipeImage, Long> {
 
@@ -15,4 +17,9 @@ public interface RecipeImageRepository extends JpaRepository<RecipeImage, Long> 
     Optional<RecipeImage> findByImageUrl(String imageUrl);
 
     void deleteAllByRecipe(Recipe recipe);
+
+    @Modifying
+    @Query("DELETE from RecipeImage ri where ri.imageUrl = :imageUrl")
+    void deleteByImageUrl(String imageUrl);
+
 }

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
@@ -1,31 +1,27 @@
 package com.example.dgbackend.domain.recipeimage.service;
 
 import com.example.dgbackend.domain.recipe.Recipe;
-import com.example.dgbackend.domain.recipe.repository.RecipeRepository;
-import com.example.dgbackend.domain.recipe.service.RecipeService;
 import com.example.dgbackend.domain.recipeimage.RecipeImage;
-import com.example.dgbackend.domain.recipeimage.dto.RecipeImageRequest;
 import com.example.dgbackend.domain.recipeimage.dto.RecipeImageResponse;
-import com.example.dgbackend.domain.recipeimage.dto.RecipeImageVO;
 import com.example.dgbackend.domain.recipeimage.repository.RecipeImageRepository;
 import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
 import com.example.dgbackend.global.exception.ApiException;
 import com.example.dgbackend.global.s3.S3Service;
 import com.example.dgbackend.global.s3.dto.S3Result;
-import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 @Slf4j
 public class RecipeImageService {
 
     private final RecipeImageRepository recipeImageRepository;
-    private final RecipeRepository recipeRepository;
 
     private final S3Service s3Service;
 
@@ -33,30 +29,6 @@ public class RecipeImageService {
         return recipeImageRepository.findAllByRecipeId(recipeId).stream()
             .map(RecipeImage::getImageUrl)
             .toList();
-    }
-
-    @Transactional
-    public RecipeImageResponse createRecipeImage(RecipeImageVO.FileVO request) {
-        Recipe recipe = recipeRepository.findById(request.getRecipeId())
-            .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE));
-
-        //파일 없을 시 예외처리
-        List<MultipartFile> multipartFiles = validFileList(request.getFileList());
-
-        //S3에 이미지 업로드하고 URL 받아오기
-        List<String> imageURLs = s3Service.uploadFile(multipartFiles).stream()
-            .map(S3Result::getImgUrl)
-            .toList();
-
-        //RecipeImage(url 리스트, recipe) 엔티티 생성
-        List<RecipeImage> recipeImages = imageURLs.stream()
-            .map(imageURL -> RecipeImageRequest.toEntity(recipe, imageURL))
-            .toList();
-
-        //RecipeImage 엔티티 모두 저장
-        recipeImageRepository.saveAll(recipeImages);
-
-        return RecipeImageResponse.toURLResponse(recipe);
     }
 
     //파일 없을 시 예외처리
@@ -67,31 +39,6 @@ public class RecipeImageService {
         }
 
         return request;
-    }
-
-    @Transactional
-    public RecipeImageResponse updateRecipeImage(RecipeImageVO.FileVO request) {
-        Recipe recipe = recipeRepository.findById(request.getRecipeId())
-            .orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_RECIPE));
-
-        //새로운 이미지 업로드
-        if (request.getFileList() != null && !request.getFileList().isEmpty()) {
-            createRecipeImage(request);
-        }
-
-        List<String> deleteFileUrlList = request.getDeleteFileUrlList();
-
-        //삭제 요청 이미지 삭제
-        if (deleteFileUrlList != null && !deleteFileUrlList.isEmpty()) {
-            deleteFileUrlList.forEach(
-                deleteFileUrl -> {
-                    deleteRecipeImage(deleteFileUrl);
-                    s3Service.deleteFile(deleteFileUrl);
-                }
-            );
-        }
-
-        return RecipeImageResponse.toURLResponse(recipe);
     }
 
     //recipeImageRepository에서 imageUrl로 조회해서 있으면 삭제하고 s3에서도 삭제
@@ -128,6 +75,65 @@ public class RecipeImageService {
 
     private List<RecipeImage> loadImage(Long recipeId) {
         return recipeImageRepository.findAllByRecipeId(recipeId);
+    }
+
+    public RecipeImageResponse.RecipeImageResult uploadRecipeImage(
+        List<MultipartFile> requestFiles) {
+
+        List<MultipartFile> multipartFiles = validFileList(requestFiles);
+
+        // S3에 이미지 업로드
+        List<String> imageUrls = s3Service.uploadFile(multipartFiles)
+            .stream()
+            .map(S3Result::getImgUrl)
+            .toList();
+
+        return RecipeImageResponse.toRecipeImageResult(imageUrls);
+
+    }
+
+    public void updateRecipeImage(Recipe recipe, List<String> recipeImageList) {
+
+        // 1. 기존의 이미지 파일 조회
+        List<String> existRecipeImageUrls = recipeImageRepository.findAllByRecipeId(recipe.getId())
+            .stream()
+            .map(RecipeImage::getImageUrl)
+            .toList();
+
+        // 2. 수정하면서 없어진 이미지를 S3에서 삭제하기
+        removeCancelledRecipeImage(recipeImageList, existRecipeImageUrls);
+
+        // 3. 새로 추가된 이미지 RecipeImage에 저장하기 (S3에 저장하기)
+        addNewRecipeImage(recipe, recipeImageList, existRecipeImageUrls);
+
+    }
+
+    public void removeCancelledRecipeImage(List<String> recipeImageList,
+        List<String> existRecipeImageUrls) {
+
+        List<String> delImageUrls = existRecipeImageUrls.stream()
+            .filter(existImage -> !recipeImageList.contains(existImage))
+            .toList();
+
+        delImageUrls.forEach(recipeImageRepository::deleteByImageUrl);
+        delImageUrls.forEach(s3Service::deleteFile);
+
+    }
+
+    public void addNewRecipeImage(Recipe recipe, List<String> recipeImageList,
+        List<String> existRecipeImageUrls) {
+
+        List<String> addImageUrls = recipeImageList.stream()
+            .filter(request -> !existRecipeImageUrls.contains(request))
+            .toList();
+
+        List<RecipeImage> recipeImages = addImageUrls.stream()
+            .map(image -> RecipeImage.builder()
+                .recipe(recipe)
+                .imageUrl(image)
+                .build())
+            .toList();
+        recipeImages.forEach(recipe::addRecipeImage);
     }
 
 

--- a/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
+++ b/src/main/java/com/example/dgbackend/domain/recipeimage/service/RecipeImageService.java
@@ -48,7 +48,6 @@ public class RecipeImageService {
             .ifPresentOrElse(recipeImageEntity -> {
                     s3Service.deleteFile(recipeImageEntity.getImageUrl());
                     recipeImageRepository.delete(recipeImageEntity);
-                    ;
                 },
                 () -> {
                     throw new ApiException(ErrorStatus._EMPTY_RECIPE_IMAGE);


### PR DESCRIPTION
## 요약

- Recipe Image 업로드 방식을 Combination Image와 동일하게 수정 하였습니다.

## 상세 내용

- 기존 Combination Image 업로드 방식과 동일하게 수정 및 기존 로직 삭제
- 관련하여 DTO 수정 및 Entity에 메소드를 추가하였습니다.
- 이와 관련하여 기존 api는 삭제하였습니다.

## 테스트 내용
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/37d6e281-4c8c-41d2-9465-6aeca74dcac9">

위와 같이 작성 후, 이미지 수정 진행

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/868afe53-f4ff-4475-8aa7-8c45d05a9b60">
두번째 파일만 삭제 후 조회 확인

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/98354963-146e-4b61-9f8c-e33a10702d75">
DB에서도 삭제 확인


## 질문 및 이외 사항

- 기존 Combination Image 업로드 방식과 똑같이 구현했지만, 삭제가 처리되지 않고 남아있는 문제가 발생하여 오래걸렸습니다.
```
    @Modifying
    @Query("DELETE from RecipeImage ri where ri.imageUrl = :imageUrl")
    void deleteByImageUrl(String imageUrl);
```
위와 같이 JPQL을 통해 구현하니 잘 작동하였습니다. 기존 Combination Image와 동일하게 작성했는데, 해당 문제가 왜 발생했는 지 아직 잘 모르겠습니다 ㅠㅠ 더 알아보는 중인데, 일단 모이치가 수정해야해서 Merge하려고 합니다!
관련 이슈 아시는 분 있으면 코멘트 부탁드립니다!

## 이슈 번호

- close #239 