### PR TITLE
[Fix] 닉네임 중복 검사 로직 추가

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/member/service/MemberCommandServiceImpl.java
@@ -6,6 +6,8 @@ import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.member.dto.MemberRequest;
 import com.example.dgbackend.domain.member.dto.MemberResponse;
 import com.example.dgbackend.domain.member.repository.MemberRepository;
+import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
+import com.example.dgbackend.global.exception.ApiException;
 import com.example.dgbackend.global.s3.S3Service;
 
 import lombok.RequiredArgsConstructor;
@@ -42,6 +44,11 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     @Override
     public MemberResponse.GetMember patchMember(Member member,
         MemberRequest.PatchMember patchMember) {
+
+        if (memberRepository.existsByNickName(patchMember.getNickName())) {
+            throw new ApiException(ErrorStatus._DUPLICATE_NICKNAME);
+        }
+
         member.setName(patchMember.getName());
         member.setNickName(patchMember.getNickName());
         member.setBirthDate(patchMember.getBirthDate());


### PR DESCRIPTION
## 요약

- 회원정보 수정 시에 닉네임 중복 검사하는 로직 추가

## 상세 내용

- 수정 성공시 
<img width="1426" alt="스크린샷 2024-09-01 오후 6 27 24" src="https://github.com/user-attachments/assets/e92e383d-0cd5-4e85-83d3-17e0cdffa8b2">

- 중복되는 닉네임이 있을 떄 
<img width="1423" alt="스크린샷 2024-09-01 오후 6 27 51" src="https://github.com/user-attachments/assets/098f2163-22e2-415c-97c3-209941a55f33">

## 질문 및 이외 사항

-

## 이슈 번호

- #257