### PR TITLE
[FEAT] 추천 이미지 캐싱 구현

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/CachedRecommendImage.java
+++ b/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/CachedRecommendImage.java
@@ -1,0 +1,31 @@
+package com.example.dgbackend.domain.cachedRecommendImage;
+
+import com.example.dgbackend.global.common.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class CachedRecommendImage extends BaseTimeEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @NotNull
+    private String foodName;
+    @NotNull
+    private String drinkName;
+    @NotNull
+    private String imageUrl;
+}

--- a/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/CachedRecommendImage.java
+++ b/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/CachedRecommendImage.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class CachedRecommendImage extends BaseTimeEntity{
+public class CachedRecommendImage extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/repository/CachedRecommendImageRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/repository/CachedRecommendImageRepository.java
@@ -1,0 +1,14 @@
+package com.example.dgbackend.domain.cachedRecommendImage.repository;
+
+import com.example.dgbackend.domain.cachedRecommendImage.CachedRecommendImage;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CachedRecommendImageRepository extends JpaRepository<CachedRecommendImage, Long> {
+    Optional<List<CachedRecommendImage>> findAllByFoodNameAndDrinkName(String foodName, String drinkName);
+    Optional<CachedRecommendImage> findByImageUrl(String imageUrl);
+    void deleteAllByCreatedAtBefore(LocalDateTime dateTime);
+
+}

--- a/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/repository/CachedRecommendImageRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/repository/CachedRecommendImageRepository.java
@@ -7,8 +7,12 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CachedRecommendImageRepository extends JpaRepository<CachedRecommendImage, Long> {
-    Optional<List<CachedRecommendImage>> findAllByFoodNameAndDrinkName(String foodName, String drinkName);
+
+    Optional<List<CachedRecommendImage>> findAllByFoodNameAndDrinkName(String foodName,
+        String drinkName);
+
     Optional<CachedRecommendImage> findByImageUrl(String imageUrl);
+
     void deleteAllByCreatedAtBefore(LocalDateTime dateTime);
 
 }

--- a/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageCommandService.java
@@ -3,6 +3,8 @@ package com.example.dgbackend.domain.cachedRecommendImage.service;
 import java.time.LocalDateTime;
 
 public interface CachedRecommendImageCommandService {
+
     void saveCachedRecommendImage(String foodName, String drinkName, String imageUrl);
+
     void deleteAllByTTL(LocalDateTime dateTime);
 }

--- a/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageCommandService.java
+++ b/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageCommandService.java
@@ -1,0 +1,8 @@
+package com.example.dgbackend.domain.cachedRecommendImage.service;
+
+import java.time.LocalDateTime;
+
+public interface CachedRecommendImageCommandService {
+    void saveCachedRecommendImage(String foodName, String drinkName, String imageUrl);
+    void deleteAllByTTL(LocalDateTime dateTime);
+}

--- a/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageCommandServiceImpl.java
@@ -1,0 +1,32 @@
+package com.example.dgbackend.domain.cachedRecommendImage.service;
+
+import com.example.dgbackend.domain.cachedRecommendImage.CachedRecommendImage;
+import com.example.dgbackend.domain.cachedRecommendImage.repository.CachedRecommendImageRepository;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CachedRecommendImageCommandServiceImpl implements CachedRecommendImageCommandService{
+    private final CachedRecommendImageRepository cachedRecommendImageRepository;
+
+    @Override
+    public void saveCachedRecommendImage(String foodName, String drinkName, String imageUrl) {
+        if(cachedRecommendImageRepository.findByImageUrl(imageUrl).isPresent())
+            return;
+
+        cachedRecommendImageRepository.save(CachedRecommendImage.builder()
+            .foodName(foodName)
+            .drinkName(drinkName)
+            .imageUrl(imageUrl)
+            .build());
+    }
+
+    @Override
+    public void deleteAllByTTL(LocalDateTime dateTime) {
+        cachedRecommendImageRepository.deleteAllByCreatedAtBefore(dateTime);
+    }
+}

--- a/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageCommandServiceImpl.java
@@ -10,13 +10,15 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class CachedRecommendImageCommandServiceImpl implements CachedRecommendImageCommandService{
+public class CachedRecommendImageCommandServiceImpl implements CachedRecommendImageCommandService {
+
     private final CachedRecommendImageRepository cachedRecommendImageRepository;
 
     @Override
     public void saveCachedRecommendImage(String foodName, String drinkName, String imageUrl) {
-        if(cachedRecommendImageRepository.findByImageUrl(imageUrl).isPresent())
+        if (cachedRecommendImageRepository.findByImageUrl(imageUrl).isPresent()) {
             return;
+        }
 
         cachedRecommendImageRepository.save(CachedRecommendImage.builder()
             .foodName(foodName)

--- a/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageQueryService.java
@@ -1,0 +1,8 @@
+package com.example.dgbackend.domain.cachedRecommendImage.service;
+
+import com.example.dgbackend.domain.recommend.Recommend;
+import java.util.List;
+
+public interface CachedRecommendImageQueryService {
+    List<String> getCachedImageUrl(String foodName, String drinkName);
+}

--- a/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageQueryService.java
@@ -4,5 +4,6 @@ import com.example.dgbackend.domain.recommend.Recommend;
 import java.util.List;
 
 public interface CachedRecommendImageQueryService {
+
     List<String> getCachedImageUrl(String foodName, String drinkName);
 }

--- a/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageQueryServiceImpl.java
@@ -1,0 +1,22 @@
+package com.example.dgbackend.domain.cachedRecommendImage.service;
+
+import com.example.dgbackend.domain.cachedRecommendImage.CachedRecommendImage;
+import com.example.dgbackend.domain.cachedRecommendImage.repository.CachedRecommendImageRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CachedRecommendImageQueryServiceImpl implements CachedRecommendImageQueryService{
+    private final CachedRecommendImageRepository cachedRecommendImageRepository;
+
+    @Override
+    public List<String> getCachedImageUrl(String foodName, String drinkName) {
+        return cachedRecommendImageRepository.findAllByFoodNameAndDrinkName(foodName, drinkName).orElse(new ArrayList<>())
+            .stream().map(CachedRecommendImage::getImageUrl).toList();
+    }
+}

--- a/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageQueryServiceImpl.java
@@ -11,12 +11,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class CachedRecommendImageQueryServiceImpl implements CachedRecommendImageQueryService{
+public class CachedRecommendImageQueryServiceImpl implements CachedRecommendImageQueryService {
+
     private final CachedRecommendImageRepository cachedRecommendImageRepository;
 
     @Override
     public List<String> getCachedImageUrl(String foodName, String drinkName) {
-        return cachedRecommendImageRepository.findAllByFoodNameAndDrinkName(foodName, drinkName).orElse(new ArrayList<>())
+        return cachedRecommendImageRepository.findAllByFoodNameAndDrinkName(foodName, drinkName)
+            .orElse(new ArrayList<>())
             .stream().map(CachedRecommendImage::getImageUrl).toList();
     }
 }

--- a/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageScheduler.java
+++ b/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageScheduler.java
@@ -1,0 +1,17 @@
+package com.example.dgbackend.domain.cachedRecommendImage.service;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CachedRecommendImageScheduler {
+    private final CachedRecommendImageCommandService cachedRecommendImageCommandService;
+
+    @Scheduled(cron = "0 53 16 * * *")
+    public void deleteExpiredCachedRecommendImage() {
+        cachedRecommendImageCommandService.deleteAllByTTL(LocalDateTime.now().minusDays(7));
+    }
+}

--- a/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageScheduler.java
+++ b/src/main/java/com/example/dgbackend/domain/cachedRecommendImage/service/CachedRecommendImageScheduler.java
@@ -8,9 +8,10 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class CachedRecommendImageScheduler {
+
     private final CachedRecommendImageCommandService cachedRecommendImageCommandService;
 
-    @Scheduled(cron = "0 53 16 * * *")
+    @Scheduled(cron = "1 0 0 * * *")
     public void deleteExpiredCachedRecommendImage() {
         cachedRecommendImageCommandService.deleteAllByTTL(LocalDateTime.now().minusDays(7));
     }

--- a/src/main/java/com/example/dgbackend/domain/recommend/repository/RecommendRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/repository/RecommendRepository.java
@@ -20,7 +20,6 @@ public interface RecommendRepository extends JpaRepository<Recommend, Long> {
     @Modifying
     @Query(value = "DELETE FROM recommend WHERE member_id = :memberId", nativeQuery = true)
     void deleteAllByMemberIdWithNativeQuery(Long memberId);
-    
-    @Query("SELECT r.imageUrl FROM Recommend r WHERE r.foodName = :foodName AND r.drinkName = :drinkName AND FUNCTION('DATEDIFF', CURRENT_DATE, r.createdAt) < :n AND r.imageUrl NOT IN (SELECT DISTINCT r2.imageUrl FROM Recommend r2 WHERE r2.member.id = :memberId) GROUP BY r.imageUrl")
-    List<String> findImageUrlForCaching(Long memberId, String foodName,String drinkName,int n);
+
+    List<Recommend> findAllByFoodNameAndDrinkNameAndMemberId(String foodName, String drinkName, Long memberId);
 }

--- a/src/main/java/com/example/dgbackend/domain/recommend/repository/RecommendRepository.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/repository/RecommendRepository.java
@@ -20,4 +20,7 @@ public interface RecommendRepository extends JpaRepository<Recommend, Long> {
     @Modifying
     @Query(value = "DELETE FROM recommend WHERE member_id = :memberId", nativeQuery = true)
     void deleteAllByMemberIdWithNativeQuery(Long memberId);
+    
+    @Query("SELECT r.imageUrl FROM Recommend r WHERE r.foodName = :foodName AND r.drinkName = :drinkName AND FUNCTION('DATEDIFF', CURRENT_DATE, r.createdAt) < :n AND r.imageUrl NOT IN (SELECT DISTINCT r2.imageUrl FROM Recommend r2 WHERE r2.member.id = :memberId) GROUP BY r.imageUrl")
+    List<String> findImageUrlForCaching(Long memberId, String foodName,String drinkName,int n);
 }

--- a/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendCommandServiceImpl.java
@@ -108,7 +108,8 @@ public class RecommendCommandServiceImpl implements RecommendCommandService {
         String imageUrl = "";
         if (!cachedImages.isEmpty()) {
             List<String> duplicatedImageList = recommendRepository.findAllByFoodNameAndDrinkNameAndMemberId(
-                recommendRequestDTO.getFoodName(), drinkType, member.getId()).stream().map(Recommend::getImageUrl)
+                    recommendRequestDTO.getFoodName(), drinkType, member.getId()).stream()
+                .map(Recommend::getImageUrl)
                 .toList();
 
             for (String cachedImage : cachedImages) {
@@ -118,9 +119,10 @@ public class RecommendCommandServiceImpl implements RecommendCommandService {
                 }
             }
         }
-        if(imageUrl.isEmpty()){
+        if (imageUrl.isEmpty()) {
             imageUrl = makeCombinationImage(member, drinkType, recommendRequestDTO);
-            cachedRecommendImageCommandService.saveCachedRecommendImage(recommendRequestDTO.getFoodName(), drinkType, imageUrl);
+            cachedRecommendImageCommandService.saveCachedRecommendImage(
+                recommendRequestDTO.getFoodName(), drinkType, imageUrl);
         }
 
         //추천 결과 DB에 저장

--- a/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendCommandServiceImpl.java
@@ -101,8 +101,19 @@ public class RecommendCommandServiceImpl implements RecommendCommandService {
         String drinkType = gptResult.get("Alcohol");
         String reason = gptResult.get("Reason");
 
-        //추천 결과 이미지 생성
-        String imageUrl = makeCombinationImage(member, drinkType, recommendRequestDTO);
+        //캐싱 적용 위치
+        List<String> cachedImages = recommendRepository.findImageUrlForCaching(member.getId(),
+            recommendRequestDTO.getFoodName(), drinkType, 7);
+
+        String imageUrl = "";
+        if (cachedImages.isEmpty()) {
+            imageUrl = makeCombinationImage(member, drinkType, recommendRequestDTO);
+        }
+        else {
+            // 랜덤 혹은 뭐 어떻게든 바꿔야함
+            imageUrl = cachedImages.get(0);
+        }
+
         //추천 결과 DB에 저장
         Recommend recommend = recommendQueryService.addRecommend(member, recommendRequestDTO,
             drinkType, reason, imageUrl);

--- a/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/recommend/service/RecommendCommandServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.dgbackend.domain.recommend.service;
 
+import com.example.dgbackend.domain.cachedRecommendImage.service.CachedRecommendImageCommandService;
+import com.example.dgbackend.domain.cachedRecommendImage.service.CachedRecommendImageQueryService;
 import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.recommend.Recommend;
 import com.example.dgbackend.domain.recommend.dto.RecommendRequest;
@@ -34,6 +36,8 @@ public class RecommendCommandServiceImpl implements RecommendCommandService {
 
     private final RecommendRepository recommendRepository;
     private final RecommendQueryService recommendQueryService;
+    private final CachedRecommendImageQueryService cachedRecommendImageQueryService;
+    private final CachedRecommendImageCommandService cachedRecommendImageCommandService;
     private final S3Service s3Service;
 
     //GPT 관련 변수
@@ -64,9 +68,6 @@ public class RecommendCommandServiceImpl implements RecommendCommandService {
         if (recommendRequestDTO.getFoodName() == null) {
             throw new ApiException(ErrorStatus._NULL_FOOD_NAME);
         }
-
-        // 사용자 선호 정보 추출을 위한 Member 객체 생성
-//        Member member = memberRepository.findById(memberID).orElseThrow(() -> new ApiException(ErrorStatus._EMPTY_MEMBER));
 
         //GPT API 요청 헤더 설정
         HttpHeaders headers = new HttpHeaders();
@@ -101,17 +102,25 @@ public class RecommendCommandServiceImpl implements RecommendCommandService {
         String drinkType = gptResult.get("Alcohol");
         String reason = gptResult.get("Reason");
 
-        //캐싱 적용 위치
-        List<String> cachedImages = recommendRepository.findImageUrlForCaching(member.getId(),
-            recommendRequestDTO.getFoodName(), drinkType, 7);
+        List<String> cachedImages = cachedRecommendImageQueryService
+            .getCachedImageUrl(recommendRequestDTO.getFoodName(), drinkType);
 
         String imageUrl = "";
-        if (cachedImages.isEmpty()) {
-            imageUrl = makeCombinationImage(member, drinkType, recommendRequestDTO);
+        if (!cachedImages.isEmpty()) {
+            List<String> duplicatedImageList = recommendRepository.findAllByFoodNameAndDrinkNameAndMemberId(
+                recommendRequestDTO.getFoodName(), drinkType, member.getId()).stream().map(Recommend::getImageUrl)
+                .toList();
+
+            for (String cachedImage : cachedImages) {
+                if (!duplicatedImageList.contains(cachedImage)) {
+                    imageUrl = cachedImage;
+                    break;
+                }
+            }
         }
-        else {
-            // 랜덤 혹은 뭐 어떻게든 바꿔야함
-            imageUrl = cachedImages.get(0);
+        if(imageUrl.isEmpty()){
+            imageUrl = makeCombinationImage(member, drinkType, recommendRequestDTO);
+            cachedRecommendImageCommandService.saveCachedRecommendImage(recommendRequestDTO.getFoodName(), drinkType, imageUrl);
         }
 
         //추천 결과 DB에 저장


### PR DESCRIPTION
## 요약

- CachedRecommendImage 캐싱테이블 추가
- 추천 로직에서 캐싱테이블 조회 로직 추가
- 캐시 TTL관리를 위한 스케줄러 구현 (매일 0시 0분 1초 실행)

## 상세 내용
캐싱 전 소요시간 약 19초
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/76c317a4-3320-44aa-b5bf-57521fcb1ba3">

캐시 hit 소요시간 약 3초
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/fe835efc-7eaa-4b69-a378-f23ae5882f05">


## 질문 및 이외 사항

-

## 이슈 번호

- #170 