### PR TITLE
[FEAT] 추천 정보 get API 구현

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/member/controller/MemberRestController.java
+++ b/src/main/java/com/example/dgbackend/domain/member/controller/MemberRestController.java
@@ -28,6 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberRestController {
 
     private final MemberCommandService memberCommandService;
+    private final MemberQueryService memberQueryService;
 
     @Operation(summary = "회원 추천 정보 저장", description = "회원 추천 정보를 저장합니다.")
     @ApiResponses(value = {
@@ -38,6 +39,16 @@ public class MemberRestController {
         @MemberObject Member member, @RequestBody MemberRequest.RecommendInfoDTO recommendInfoDTO) {
         return ApiResponse.onSuccess(
             memberCommandService.patchRecommendInfo(member, recommendInfoDTO));
+    }
+
+    @Operation(summary = "회원 추천 정보 조회", description = "회원 추천 정보를 조회합니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 추천 정보 조회 성공"),
+    })
+    @GetMapping("/recommend-info")
+    public ApiResponse<MemberResponse.RecommendInfoDTO> getRecommendInfo(
+        @MemberObject Member member) {
+        return ApiResponse.onSuccess(memberQueryService.getRecommendInfo(member));
     }
 
     @Operation(summary = "회원 정보 수정", description = "회원 정보를 수정합니다.")

--- a/src/main/java/com/example/dgbackend/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/example/dgbackend/domain/member/service/MemberQueryService.java
@@ -1,6 +1,7 @@
 package com.example.dgbackend.domain.member.service;
 
 import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.member.dto.MemberResponse.RecommendInfoDTO;
 import java.util.Optional;
 
 public interface MemberQueryService {
@@ -10,4 +11,8 @@ public interface MemberQueryService {
     Boolean existsByNickname(String nickname);
 
     Optional<Member> findByProviderAndProviderId(String provider, String providerId);
+
+    RecommendInfoDTO getRecommendInfo(Member member);
+
+
 }

--- a/src/main/java/com/example/dgbackend/domain/member/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/member/service/MemberQueryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.dgbackend.domain.member.service;
 
 import com.example.dgbackend.domain.member.Member;
+import com.example.dgbackend.domain.member.dto.MemberResponse.RecommendInfoDTO;
 import com.example.dgbackend.domain.member.repository.MemberRepository;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
@@ -27,5 +28,15 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     @Override
     public Optional<Member> findByProviderAndProviderId(String provider, String providerId) {
         return memberRepository.findByProviderAndProviderId(provider, providerId);
+    }
+
+    @Override
+    public RecommendInfoDTO getRecommendInfo(Member member) {
+        return RecommendInfoDTO.builder()
+            .drinkingLimit(member.getDrinkingLimit())
+            .preferredAlcoholType(member.getPreferredAlcoholType())
+            .preferredAlcoholDegree(member.getPreferredAlcoholDegree())
+            .drinkingTimes(member.getDrinkingTimes())
+            .build();
     }
 }


### PR DESCRIPTION
## 요약

- 멤버의 추천 기본 정보 GET API를 구현합니다.

## 상세 내용

- recommend-info url로 GET api를 구현했습니다.
<img width="1405" alt="스크린샷 2024-09-22 오후 10 20 47" src="https://github.com/user-attachments/assets/d4022912-13c5-4644-aa24-97ec3dff8250">


## 질문 및 이외 사항

-

## 이슈 번호

- #262 