### PR TITLE
[FIX] 닉네임 중복 검사 로직 변경 & 만료시간 추가

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/member/service/MemberCommandServiceImpl.java
@@ -45,12 +45,14 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     public MemberResponse.GetMember patchMember(Member member,
         MemberRequest.PatchMember patchMember) {
 
-        if (memberRepository.existsByNickName(patchMember.getNickName())) {
-            throw new ApiException(ErrorStatus._DUPLICATE_NICKNAME);
+        if (!member.getNickName().equals(patchMember.getNickName())) {
+            if (memberRepository.existsByNickName(patchMember.getNickName())) {
+                throw new ApiException(ErrorStatus._DUPLICATE_NICKNAME);
+            }
+            member.setNickName(patchMember.getNickName());
         }
 
         member.setName(patchMember.getName());
-        member.setNickName(patchMember.getNickName());
         member.setBirthDate(patchMember.getBirthDate());
         member.setPhoneNumber(patchMember.getPhoneNumber());
         member.setGender(patchMember.getGender());

--- a/src/main/java/com/example/dgbackend/global/jwt/JwtProvider.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/JwtProvider.java
@@ -65,11 +65,13 @@ public class JwtProvider {
     public String generateRefreshToken(final String id) {
         Claims claims = createClaims(id);
         Date now = new Date();
+        long expiredDate = calculateExpirationDateRefreshToken(now);
         SecretKey secretKey = generateKey();
 
         String refreshToken = Jwts.builder()
             .setClaims(claims)
             .setIssuedAt(now)
+            .setExpiration(new Date(expiredDate))
             .signWith(secretKey, SignatureAlgorithm.HS256)
             .compact();
 
@@ -88,6 +90,10 @@ public class JwtProvider {
     // JWT 만료 시간 계산
     private long calculateExpirationDate(Date now) {
         return now.getTime() + ACCESS_TOKEN_VALID_TIME;
+    }
+
+    private long calculateExpirationDateRefreshToken(Date now) {
+        return now.getTime() + REFRESH_TOKEN_VALID_TIME;
     }
 
     //TODO: 여기 Exception 넘겨버리기


### PR DESCRIPTION
## 요약

- 멤버 정보 수정 시 본인 닉네임 중복 검사 제외
- 리프레시 토큰 만료기한 추가

## 상세 내용
- 기존 닉네임으로 수정 요청하여도 중복에 걸리지 않음
<img width="1425" alt="스크린샷 2024-09-24 오전 2 27 27" src="https://github.com/user-attachments/assets/c9baee0a-da9d-4a64-be06-2c1fb795ec5a">

- 토큰 해독시 만료 기한 확인 가능
<img width="1192" alt="스크린샷 2024-09-24 오전 2 25 49" src="https://github.com/user-attachments/assets/dd9966ed-9098-4a2d-8dbd-42799667e8dc">


## 질문 및 이외 사항

-

## 이슈 번호

- #264 