### PR TITLE
Fix: 프로필 사진 수정 로직 수정

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/member/controller/MemberRestController.java
+++ b/src/main/java/com/example/dgbackend/domain/member/controller/MemberRestController.java
@@ -56,7 +56,7 @@ public class MemberRestController {
     })
     @PostMapping("/profile-image")
     public ApiResponse<MemberResponse.GetMember> patchProfileImage(@MemberObject Member member,
-        @RequestParam(name = "profileImage") MultipartFile patchProfileImage) {
+        @RequestParam(name = "profileImage", required = false) MultipartFile patchProfileImage) {
 
         return ApiResponse.onSuccess(
             memberCommandService.patchProfileImage(member, patchProfileImage));

--- a/src/main/java/com/example/dgbackend/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/member/service/MemberCommandServiceImpl.java
@@ -11,6 +11,7 @@ import com.example.dgbackend.global.exception.ApiException;
 import com.example.dgbackend.global.s3.S3Service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class MemberCommandServiceImpl implements MemberCommandService {
 
     @Autowired
@@ -66,10 +68,17 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         String originUrl = member.getProfileImageUrl();
 
         if (originUrl != null) {
+            log.info("--------------------------lgogogo");
             s3Service.deleteFile(originUrl);
         }
-        String profileImageUrl = (s3Service.uploadOneFile(multipartFile).getImgUrl());
-        member.updateProfileImageUrl(profileImageUrl);
+
+        if (multipartFile !=  null) {
+            log.info("-----------------------------------보냄");
+            String profileImageUrl = (s3Service.uploadOneFile(multipartFile).getImgUrl());
+            member.updateProfileImageUrl(profileImageUrl);
+        } else {
+            member.updateProfileImageUrl(null);
+        }
 
         return MemberResponse.toGetMember(member);
     }

--- a/src/main/java/com/example/dgbackend/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/member/service/MemberCommandServiceImpl.java
@@ -6,6 +6,8 @@ import com.example.dgbackend.domain.member.Member;
 import com.example.dgbackend.domain.member.dto.MemberRequest;
 import com.example.dgbackend.domain.member.dto.MemberResponse;
 import com.example.dgbackend.domain.member.repository.MemberRepository;
+import com.example.dgbackend.global.common.response.code.status.ErrorStatus;
+import com.example.dgbackend.global.exception.ApiException;
 import com.example.dgbackend.global.s3.S3Service;
 
 import lombok.RequiredArgsConstructor;
@@ -42,6 +44,11 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     @Override
     public MemberResponse.GetMember patchMember(Member member,
         MemberRequest.PatchMember patchMember) {
+
+        if (memberRepository.existsByNickName(patchMember.getNickName())) {
+            throw new ApiException(ErrorStatus._DUPLICATE_NICKNAME);
+        }
+
         member.setName(patchMember.getName());
         member.setNickName(patchMember.getNickName());
         member.setBirthDate(patchMember.getBirthDate());

--- a/src/main/java/com/example/dgbackend/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/member/service/MemberCommandServiceImpl.java
@@ -67,13 +67,11 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     public MemberResponse.GetMember patchProfileImage(Member member, MultipartFile multipartFile) {
         String originUrl = member.getProfileImageUrl();
 
-        if (originUrl != null) {
-            log.info("--------------------------lgogogo");
+        if (originUrl != null && !originUrl.equals("")) {
             s3Service.deleteFile(originUrl);
         }
 
         if (multipartFile !=  null) {
-            log.info("-----------------------------------보냄");
             String profileImageUrl = (s3Service.uploadOneFile(multipartFile).getImgUrl());
             member.updateProfileImageUrl(profileImageUrl);
         } else {

--- a/src/main/java/com/example/dgbackend/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/dgbackend/domain/member/service/MemberCommandServiceImpl.java
@@ -45,12 +45,14 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     public MemberResponse.GetMember patchMember(Member member,
         MemberRequest.PatchMember patchMember) {
 
-        if (memberRepository.existsByNickName(patchMember.getNickName())) {
-            throw new ApiException(ErrorStatus._DUPLICATE_NICKNAME);
+        if (!member.getNickName().equals(patchMember.getNickName())) {
+            if (memberRepository.existsByNickName(patchMember.getNickName())) {
+                throw new ApiException(ErrorStatus._DUPLICATE_NICKNAME);
+            }
+            member.setNickName(patchMember.getNickName());
         }
 
         member.setName(patchMember.getName());
-        member.setNickName(patchMember.getNickName());
         member.setBirthDate(patchMember.getBirthDate());
         member.setPhoneNumber(patchMember.getPhoneNumber());
         member.setGender(patchMember.getGender());

--- a/src/main/java/com/example/dgbackend/global/jwt/JwtProvider.java
+++ b/src/main/java/com/example/dgbackend/global/jwt/JwtProvider.java
@@ -65,11 +65,13 @@ public class JwtProvider {
     public String generateRefreshToken(final String id) {
         Claims claims = createClaims(id);
         Date now = new Date();
+        long expiredDate = calculateExpirationDateRefreshToken(now);
         SecretKey secretKey = generateKey();
 
         String refreshToken = Jwts.builder()
             .setClaims(claims)
             .setIssuedAt(now)
+            .setExpiration(new Date(expiredDate))
             .signWith(secretKey, SignatureAlgorithm.HS256)
             .compact();
 
@@ -88,6 +90,10 @@ public class JwtProvider {
     // JWT 만료 시간 계산
     private long calculateExpirationDate(Date now) {
         return now.getTime() + ACCESS_TOKEN_VALID_TIME;
+    }
+
+    private long calculateExpirationDateRefreshToken(Date now) {
+        return now.getTime() + REFRESH_TOKEN_VALID_TIME;
     }
 
     //TODO: 여기 Exception 넘겨버리기

--- a/src/main/java/com/example/dgbackend/global/s3/S3Service.java
+++ b/src/main/java/com/example/dgbackend/global/s3/S3Service.java
@@ -93,9 +93,11 @@ public class S3Service {
     }
 
     public void deleteFile(String fileName) {
-        String s3File = extractKeyFromUrl(fileName);
-        if (s3File != null) {
+        try {
+            String s3File = extractKeyFromUrl(fileName);
             amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, s3File));
+        } catch (AmazonServiceException e) {
+            throw new ApiException(ErrorStatus._S3_IMAGE_NOT_FOUND);
         }
     }
 
@@ -104,8 +106,7 @@ public class S3Service {
         if (imageUrl.startsWith(bucketPrefix)) {
             return imageUrl.substring(bucketPrefix.length());
         } else {
-            //throw new ApiException(ErrorStatus._S3_IMAGE_NOT_FOUND);
-            return null;
+            throw new ApiException(ErrorStatus._S3_IMAGE_NOT_FOUND);
         }
     }
 }

--- a/src/main/java/com/example/dgbackend/global/s3/S3Service.java
+++ b/src/main/java/com/example/dgbackend/global/s3/S3Service.java
@@ -42,7 +42,7 @@ public class S3Service {
             return fileName.substring(fileName.lastIndexOf("."));
         } catch (StringIndexOutOfBoundsException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                    "잘못된 형식의 파일(" + fileName + ") 입니다.");
+                "잘못된 형식의 파일(" + fileName + ") 입니다.");
         }
     }
 
@@ -62,10 +62,10 @@ public class S3Service {
 
             try (InputStream inputStream = file.getInputStream()) {
                 amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream,
-                        objectMetadata).withCannedAcl(CannedAccessControlList.PublicRead));
+                    objectMetadata).withCannedAcl(CannedAccessControlList.PublicRead));
             } catch (IOException e) {
                 throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-                        "파일 업로드에 실패했습니다.");
+                    "파일 업로드에 실패했습니다.");
             }
             fileList.add(new S3Result(amazonS3Client.getUrl(bucket, fileName).toString()));
         });
@@ -81,10 +81,10 @@ public class S3Service {
 
         try (InputStream inputStream = multipartFile.getInputStream()) {
             amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream,
-                    objectMetadata).withCannedAcl(CannedAccessControlList.PublicRead));
+                objectMetadata).withCannedAcl(CannedAccessControlList.PublicRead));
         } catch (IOException e) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-                    "파일 업로드에 실패했습니다.");
+                "파일 업로드에 실패했습니다.");
         }
 
         S3Result file = new S3Result(amazonS3Client.getUrl(bucket, fileName).toString());
@@ -93,11 +93,9 @@ public class S3Service {
     }
 
     public void deleteFile(String fileName) {
-        try {
-            String s3File = extractKeyFromUrl(fileName);
+        String s3File = extractKeyFromUrl(fileName);
+        if (s3File != null) {
             amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, s3File));
-        } catch (AmazonServiceException e) {
-            throw new ApiException(ErrorStatus._S3_IMAGE_NOT_FOUND);
         }
     }
 
@@ -106,7 +104,8 @@ public class S3Service {
         if (imageUrl.startsWith(bucketPrefix)) {
             return imageUrl.substring(bucketPrefix.length());
         } else {
-            throw new ApiException(ErrorStatus._S3_IMAGE_NOT_FOUND);
+            //throw new ApiException(ErrorStatus._S3_IMAGE_NOT_FOUND);
+            return null;
         }
     }
 }


### PR DESCRIPTION
## 요약

- profileImage에 null 값이 들어갈 수 있게 수정

## 상세 내용

- 기존 null로 설정된 이미지였으면 삭제 시 오류 발생 -> 해당 이미지가 있을 경우에만 삭제하도록 변경
- MemberController에서 해당 MultipartFile의 required 조건을 false로 명시 -> file이 null로 와도 오류 X


## 질문 및 이외 사항

-

## 이슈 번호

- #269 