### PR TITLE
Fix: 메인 조회 로직 임시조치

### DIFF
--- a/src/main/java/com/example/dgbackend/domain/combination/Combination.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/Combination.java
@@ -101,6 +101,10 @@ public class Combination extends BaseTimeEntity {
         this.state = false;
     }
 
+    public boolean isState() {
+        return state;
+    }
+
     /**
      * CombinationLike 관련 메서드
      */

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationScheduler.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationScheduler.java
@@ -91,8 +91,6 @@ public class CombinationScheduler {
         // 선택된 3개의 항목을 저장하기
         updateCombinations(topLikes);
 
-        log.info("실행됨!!!!!!1");
-
         // 주간 베스트 조합 랜덤 5개 가져오기
         List<Combination> topWeeklyLikes = getWeeklyCombinations();
         updateWeeklyCombinations(topWeeklyLikes);

--- a/src/main/java/com/example/dgbackend/domain/combination/service/CombinationScheduler.java
+++ b/src/main/java/com/example/dgbackend/domain/combination/service/CombinationScheduler.java
@@ -91,6 +91,8 @@ public class CombinationScheduler {
         // 선택된 3개의 항목을 저장하기
         updateCombinations(topLikes);
 
+        log.info("실행됨!!!!!!1");
+
         // 주간 베스트 조합 랜덤 5개 가져오기
         List<Combination> topWeeklyLikes = getWeeklyCombinations();
         updateWeeklyCombinations(topWeeklyLikes);
@@ -122,6 +124,18 @@ public class CombinationScheduler {
     @Transactional
     public CombinationResponse.CombinationMainPreviewList getMainTodayCombinationList() {
         List<Combination> combinations = this.getMainCombination();
+
+        boolean needsUpdate = combinations.stream().anyMatch(combination -> {
+            Combination latestCombination = combinationRepository.findById(combination.getId()).orElse(null);
+            return latestCombination == null || !latestCombination.isState();
+        });
+
+        if (needsUpdate) {
+            log.info("소프트 삭제된 조합이 발견되어 리스트를 갱신합니다.");
+            updateRandomTopLikes();
+            // 리스트 갱신 후 다시 가져오기
+            combinations = this.getMainCombination();
+        }
 
         // 이미지와 해시태그 옵션 리스트 가져오기
         List<CombinationImage> combinationImages = combinations.stream()

--- a/src/main/java/com/example/dgbackend/domain/recipe/Recipe.java
+++ b/src/main/java/com/example/dgbackend/domain/recipe/Recipe.java
@@ -89,6 +89,10 @@ public class Recipe extends BaseTimeEntity {
         return this;
     }
 
+    public boolean isState() {
+        return this.state;
+    }
+
     public void changeLikeCount(boolean isIncrease) {
 
         if (isIncrease) {


### PR DESCRIPTION
## 요약

- 메인에서 불러올 때 셋 중 하나라도 삭제된 항목이 있으면, 랜덤 로직을 다시 불러옴

## 상세 내용

- RecipeSchedular, CombinationSchedular 둘 다 동일하게 변경
- 메인에서 조회 호출이 있을 경우, 미리 저장된 항목 중 하나라도 삭제가 되어있으면 random top 3를 다시 뽑아서 저장 후 반환
- 자정에 똑같이 한 번씩 돌아감 

## 질문 및 이외 사항

-

## 이슈 번호

-